### PR TITLE
feat(tracking): add tracking info page

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,8 @@ app.get('/mentions-legales', (req, res) => {
   res.render('legalNotice')
 })
 
-app.get('/suivi', (req, res) => {
-  res.render('suivi')
+app.get('/donnees-personnelles-et-gestion-des-cookies', (req, res) => {
+  res.render('données-personnelles-et-gestion-des-cookies')
 })
 
 module.exports = app.listen(port, () => {

--- a/index.js
+++ b/index.js
@@ -36,6 +36,10 @@ app.get('/mentions-legales', (req, res) => {
   res.render('legalNotice')
 })
 
+app.get('/suivi', (req, res) => {
+  res.render('suivi')
+})
+
 module.exports = app.listen(port, () => {
   console.log(`${appName} listening at http://localhost:${port}`)
 })

--- a/views/données-personnelles-et-gestion-des-cookies.ejs
+++ b/views/données-personnelles-et-gestion-des-cookies.ejs
@@ -7,7 +7,11 @@
 
     <p>Ce site dépose un petit fichier texte (un « cookie ») sur votre ordinateur lorsque vous le consultez. Cela nous permet de mesurer le nombre de visites et de comprendre quelles sont les pages les plus consultées.</p>
 
-    <iframe class="optout ui raised segment" src="https://stats.data.gouv.fr/index.php?module=CoreAdminHome&amp;action=optOut&amp;language=fr" style="border-width: 0px; overflow:hidden; width:100%;"></iframe>
+    <p>Information sur votre suivi : </p>
+    <iframe
+        style="border: 0; height: 100px; width: 80%"
+        src="https://stats.data.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=fr&backgroundColor=&fontColor=&fontSize=&fontFamily=%22Marianne%22%2C%20arial%2C%20sans-serif"
+        ></iframe>
 
     <h3 id="ce-site-naffiche-pas-de-bannière-de-consentement-aux-cookies-pourquoi-">Ce site n’affiche pas de bannière de consentement aux cookies, pourquoi ?</h3>
 
@@ -19,7 +23,7 @@
 
     <h3 id="je-contribue-à-enrichir-vos-données-puis-je-y-accéder">Je contribue à enrichir vos données, puis-je y accéder ?</h3>
 
-    <p>Bien sûr ! Les statistiques d’usage sont disponibles en accès libre sur <a href="https://stats.data.gouv.fr/index.php?module=CoreHome&action=index&date=yesterday&period=day&idSite=160#?idSite=160&period=day&date=yesterday&segment=&category=Dashboard_Dashboard&subcategory=1">stats.data.gouv.fr</a>.</p>
+    <p>Bien sûr ! Les statistiques d’usage sont disponibles en accès libre sur <a target="_blank" rel="noopener" href="https://stats.data.gouv.fr/index.php?module=CoreHome&action=index&date=yesterday&period=day&idSite=160#?idSite=160&period=day&date=yesterday&segment=&category=Dashboard_Dashboard&subcategory=1">stats.data.gouv.fr</a>.</p>
 
 </div>
 

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -53,7 +53,7 @@
           <a class="rf-footer__bottom-link" href="/mentions-legales#accessibilite">Accessibilité: non conforme</a>
         </li>
         <li class="rf-footer__bottom-item">
-          <a class="rf-footer__bottom-link" href="/données-personnelles-et-gestion-des-cookies">Données personnelles et gestion des cookies</a>
+          <a class="rf-footer__bottom-link" href="/donnees-personnelles-et-gestion-des-cookies">Données personnelles et gestion des cookies</a>
         </li>
         <li class="rf-footer__bottom-item">
           <a class="rf-footer__bottom-link" href="/mentions-legales">Mentions légales</a>

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -53,7 +53,7 @@
           <a class="rf-footer__bottom-link" href="/mentions-legales#accessibilite">Accessibilité: non conforme</a>
         </li>
         <li class="rf-footer__bottom-item">
-          <a class="rf-footer__bottom-link" href="/suivi">Suivi d&#39;audience et vie privée</a>
+          <a class="rf-footer__bottom-link" href="/données-personnelles-et-gestion-des-cookies">Données personnelles et gestion des cookies</a>
         </li>
         <li class="rf-footer__bottom-item">
           <a class="rf-footer__bottom-link" href="/mentions-legales">Mentions légales</a>

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -53,6 +53,9 @@
           <a class="rf-footer__bottom-link" href="/mentions-legales#accessibilite">Accessibilité: non conforme</a>
         </li>
         <li class="rf-footer__bottom-item">
+          <a class="rf-footer__bottom-link" href="/suivi">Suivi d&#39;audience et vie privée</a>
+        </li>
+        <li class="rf-footer__bottom-item">
           <a class="rf-footer__bottom-link" href="/mentions-legales">Mentions légales</a>
         </li>
       </ul>

--- a/views/suivi.ejs
+++ b/views/suivi.ejs
@@ -19,7 +19,7 @@
 
     <h3 id="je-contribue-à-enrichir-vos-données-puis-je-y-accéder">Je contribue à enrichir vos données, puis-je y accéder ?</h3>
 
-    <p>Bien sûr ! Les statistiques d’usage de la majorité de nos produits, dont <code class="language-plaintext highlighter-rouge">beta.gouv.fr</code>, sont disponibles en accès libre sur <a href="https://stats.data.gouv.fr/index.php?module=CoreHome&action=index&date=yesterday&period=day&idSite=160#?idSite=160&period=day&date=yesterday&segment=&category=Dashboard_Dashboard&subcategory=1"><code class="language-plaintext highlighter-rouge">stats.data.gouv.fr</code></a>.</p>
+    <p>Bien sûr ! Les statistiques d’usage sont disponibles en accès libre sur <a href="https://stats.data.gouv.fr/index.php?module=CoreHome&action=index&date=yesterday&period=day&idSite=160#?idSite=160&period=day&date=yesterday&segment=&category=Dashboard_Dashboard&subcategory=1">stats.data.gouv.fr</a>.</p>
 
 </div>
 

--- a/views/suivi.ejs
+++ b/views/suivi.ejs
@@ -15,7 +15,7 @@
 
     <p>Rien d’exceptionnel, pas de passe-droit lié à un <code class="language-plaintext highlighter-rouge">.gouv.fr</code>. Nous respectons simplement la loi, qui dit que certains outils de suivi d’audience, correctement configurés pour respecter la vie privée, sont exemptés d’autorisation préalable.</p>
 
-    <p>Nous utilisons pour cela <a href="https://matomo.org/">Matomo</a>, un outil <a href="https://matomo.org/free-software/">libre</a>, paramétré pour être en conformité avec la <a href="https://www.cnil.fr/fr/solutions-pour-la-mesure-daudience">recommandation « Cookies »</a> de la <abbr title="Commission Nationale de l'Informatique et des Libertés">CNIL</abbr>. Cela signifie que votre adresse IP, par exemple, est anonymisée avant d’être enregistrée. Il est donc impossible d’associer vos visites sur ce site à votre personne.</p>
+    <p>Nous utilisons pour cela <a href="https://matomo.org/" target="_blank" rel="noopener noreferrer">Matomo</a>, un outil <a href="https://matomo.org/free-software/" target="_blank" rel="noopener noreferrer">libre</a>, paramétré pour être en conformité avec la <a href="https://www.cnil.fr/fr/solutions-pour-la-mesure-daudience" target="_blank" rel="noopener noreferrer">recommandation « Cookies »</a> de la <abbr title="Commission Nationale de l'Informatique et des Libertés">CNIL</abbr>. Cela signifie que votre adresse IP, par exemple, est anonymisée avant d’être enregistrée. Il est donc impossible d’associer vos visites sur ce site à votre personne.</p>
 
     <h3 id="je-contribue-à-enrichir-vos-données-puis-je-y-accéder">Je contribue à enrichir vos données, puis-je y accéder ?</h3>
 

--- a/views/suivi.ejs
+++ b/views/suivi.ejs
@@ -1,0 +1,26 @@
+<%- include('partials/header') -%>
+
+<div class="rf-container rf-mb-5w">
+    <h1>Suivi d&#39;audience et vie privée</h1>
+
+    <h3 id="cookies-déposés-et-opt-out">Cookies déposés et opt-out</h3>
+
+    <p>Ce site dépose un petit fichier texte (un « cookie ») sur votre ordinateur lorsque vous le consultez. Cela nous permet de mesurer le nombre de visites et de comprendre quelles sont les pages les plus consultées.</p>
+
+    <iframe class="optout ui raised segment" src="https://stats.data.gouv.fr/index.php?module=CoreAdminHome&amp;action=optOut&amp;language=fr" style="border-width: 0px; overflow:hidden; width:100%;"></iframe>
+
+    <h3 id="ce-site-naffiche-pas-de-bannière-de-consentement-aux-cookies-pourquoi-">Ce site n’affiche pas de bannière de consentement aux cookies, pourquoi ?</h3>
+
+    <p>C’est vrai, vous n’avez pas eu à cliquer sur un bloc qui recouvre la moitié de la page pour dire que vous êtes d’accord avec le dépôt de cookies — même si vous ne savez pas ce que ça veut dire !</p>
+
+    <p>Rien d’exceptionnel, pas de passe-droit lié à un <code class="language-plaintext highlighter-rouge">.gouv.fr</code>. Nous respectons simplement la loi, qui dit que certains outils de suivi d’audience, correctement configurés pour respecter la vie privée, sont exemptés d’autorisation préalable.</p>
+
+    <p>Nous utilisons pour cela <a href="https://matomo.org/">Matomo</a>, un outil <a href="https://matomo.org/free-software/">libre</a>, paramétré pour être en conformité avec la <a href="https://www.cnil.fr/fr/solutions-pour-la-mesure-daudience">recommandation « Cookies »</a> de la <abbr title="Commission Nationale de l'Informatique et des Libertés">CNIL</abbr>. Cela signifie que votre adresse IP, par exemple, est anonymisée avant d’être enregistrée. Il est donc impossible d’associer vos visites sur ce site à votre personne.</p>
+
+    <h3 id="je-contribue-à-enrichir-vos-données-puis-je-y-accéder">Je contribue à enrichir vos données, puis-je y accéder ?</h3>
+
+    <p>Bien sûr ! Les statistiques d’usage de la majorité de nos produits, dont <code class="language-plaintext highlighter-rouge">beta.gouv.fr</code>, sont disponibles en accès libre sur <a href="https://stats.data.gouv.fr/index.php?module=CoreHome&action=index&date=yesterday&period=day&idSite=160#?idSite=160&period=day&date=yesterday&segment=&category=Dashboard_Dashboard&subcategory=1"><code class="language-plaintext highlighter-rouge">stats.data.gouv.fr</code></a>.</p>
+
+</div>
+
+<%- include('partials/footer') -%>


### PR DESCRIPTION
# But
Ajout des informations de Suivi d'audience et vie privée sur http://localhost:8080/suivi

Basé sur https://beta.gouv.fr/suivi/

Lien vers stats du site ajoutée : https://stats.data.gouv.fr/index.php?module=CoreHome&action=index&date=yesterday&period=day&idSite=160#?idSite=160&period=day&date=2021-02-11&segment=&category=Dashboard_Dashboard&subcategory=1

![image](https://user-images.githubusercontent.com/4059615/107754412-b8ff0080-6d21-11eb-9f71-bf2bc19670ea.png)
