### PR TITLE
docker: use depends_on to be sure DB is up before starting web server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,6 @@ services:
   web:
     build: .
     command: bash -c "npm run migrate && nodemon --inspect=0.0.0.0:9229 ./index.js"
-    links:
-      - db
     env_file:
       - .env
     environment:
@@ -21,3 +19,5 @@ services:
       - "9229:9229"
     volumes:
       - .:/app
+    depends_on:
+      - db


### PR DESCRIPTION
# But
Le container web peut potentiellement commencer avant la DB sans la config `depends_on`, on force l'ordre avec ces configs

Suppression de `link` comme 
> The --link flag is a legacy feature of Docker.

# Liens
https://docs.docker.com/compose/compose-file/compose-file-v3/#links
https://docs.docker.com/compose/compose-file/compose-file-v3/#depends_on