### PR TITLE
Make page titles more specific

### DIFF
--- a/controllers/appointmentsController.js
+++ b/controllers/appointmentsController.js
@@ -4,12 +4,12 @@ const format = require('../utils/format')
 
 module.exports.myAppointments = async (req, res) => {
   const appointments = await db.getAppointments()
-  res.render('myAppointments', { appointments: appointments })
+  res.render('myAppointments', { appointments: appointments, pageTitle: "Mes séances" })
 }
 
 module.exports.newAppointment = async (req, res) => {
   const patients = await db.getPatients()
-  res.render('newAppointment', {patients: patients})
+  res.render('newAppointment', {patients: patients, pageTitle: "Nouvelle séance"})
 }
 
 module.exports.createNewAppointment = async (req, res) => {

--- a/controllers/patientsController.js
+++ b/controllers/patientsController.js
@@ -2,11 +2,11 @@ const db = require('../utils/db')
 
 module.exports.myPatients = async (req, res) => {
   const patients = await db.getPatients()
-  res.render('myPatients', { patients: patients})
+  res.render('myPatients', { patients: patients, pageTitle: 'Mes patients'})
 }
 
 module.exports.newPatient = async (req, res) => {
-  res.render('newPatient')
+  res.render('newPatient', { pageTitle: 'Nouveau patient' })
 }
 
 module.exports.createNewPatient = async (req, res) => {

--- a/index.js
+++ b/index.js
@@ -74,11 +74,15 @@ if (config.featurePsyPages) {
 }
 
 app.get('/mentions-legales', (req, res) => {
-  res.render('legalNotice');
+  res.render('legalNotice', {
+    pageTitle: "Mentions Légales",
+  });
 })
 
 app.get('/donnees-personnelles-et-gestion-des-cookies', (req, res) => {
-  res.render('données-personnelles-et-gestion-des-cookies')
+  res.render('données-personnelles-et-gestion-des-cookies', {
+    pageTitle: "Données personnelles",
+  })
 })
 
 module.exports = app.listen(config.port, () => {


### PR DESCRIPTION
Page title is displayed as tab title in browser, and is useful for users using screen readers (to navigate between tabs).
Make a separate page title for each page (except landing).

Example : landing page
![image](https://user-images.githubusercontent.com/911434/108231670-46878980-7142-11eb-81ff-7d9d87c7b662.png)

vs. another page : 
![image](https://user-images.githubusercontent.com/911434/108231751-5e5f0d80-7142-11eb-8ce4-861bfddcc643.png)
