### PR TITLE
Feat : set security headers for cookies

### DIFF
--- a/controllers/dashboardController.js
+++ b/controllers/dashboardController.js
@@ -3,6 +3,7 @@ const dbAppointments = require('../db/appointments')
 const dbPatient = require('../db/patients')
 
 module.exports.dashboard = async function dashboard(req, res) {
+  console.log('dahsboardController')
   try {
     const psychologistId = cookie.getCurrentPsyId(req)
     const results = await Promise.all([

--- a/controllers/dashboardController.js
+++ b/controllers/dashboardController.js
@@ -3,7 +3,6 @@ const dbAppointments = require('../db/appointments')
 const dbPatient = require('../db/patients')
 
 module.exports.dashboard = async function dashboard(req, res) {
-  console.log('dahsboardController')
   try {
     const psychologistId = cookie.getCurrentPsyId(req)
     const results = await Promise.all([

--- a/controllers/loginController.js
+++ b/controllers/loginController.js
@@ -60,16 +60,11 @@ module.exports.getLogin = async function getLogin(req, res) {
 
       if( dbToken !== undefined ) {
         const psychologistData = await dbPsychologists.getPsychologistByEmail(dbToken.email);
-        console.log('psychologistData', psychologistData)
         cookie.createAndSetJwtCookie(res, dbToken.email, psychologistData)
-        console.log('cookie set')
         await dbLoginToken.delete(token);
-        console.log('token deleted')
         req.flash('info', `Vous êtes authentifié comme ${dbToken.email}`);
-        console.log('redirecting to', nextPage)
         return res.redirect(nextPage);
       } else {
-        console.log('Could not get token.')
         req.flash('error', 'Ce lien est invalide ou expiré. Indiquez votre email ci dessous pour en avoir un nouveau.');
       }
     }

--- a/controllers/loginController.js
+++ b/controllers/loginController.js
@@ -60,7 +60,8 @@ module.exports.getLogin = async function getLogin(req, res) {
 
       if( dbToken !== undefined ) {
         const psychologistData = await dbPsychologists.getPsychologistByEmail(dbToken.email);
-        res.cookie('token', cookie.getJwtTokenForUser(dbToken.email, psychologistData));
+        // todo(estellecomment) cookie.js should do the setting
+        res.cookie('token', cookie.getJwtTokenForUser(dbToken.email, psychologistData), cookie.headers);
         await dbLoginToken.delete(token);
         req.flash('info', `Vous êtes authentifié comme ${dbToken.email}`);
 
@@ -121,5 +122,5 @@ module.exports.postLogin = async function postLogin(req, res) {
 
 module.exports.getLogout = function getLogout (req, res) {
   req.flash('info', `Vous êtes déconnecté.`);
-  res.clearCookie('token').redirect('/');
+  res.clearCookie('token').redirect('/psychologue/login');
 };

--- a/controllers/loginController.js
+++ b/controllers/loginController.js
@@ -60,12 +60,16 @@ module.exports.getLogin = async function getLogin(req, res) {
 
       if( dbToken !== undefined ) {
         const psychologistData = await dbPsychologists.getPsychologistByEmail(dbToken.email);
+        console.log('psychologistData', psychologistData)
         cookie.createAndSetJwtCookie(res, dbToken.email, psychologistData)
+        console.log('cookie set')
         await dbLoginToken.delete(token);
+        console.log('token deleted')
         req.flash('info', `Vous êtes authentifié comme ${dbToken.email}`);
-
+        console.log('redirecting to', nextPage)
         return res.redirect(nextPage);
       } else {
+        console.log('Could not get token.')
         req.flash('error', 'Ce lien est invalide ou expiré. Indiquez votre email ci dessous pour en avoir un nouveau.');
       }
     }

--- a/controllers/loginController.js
+++ b/controllers/loginController.js
@@ -60,8 +60,7 @@ module.exports.getLogin = async function getLogin(req, res) {
 
       if( dbToken !== undefined ) {
         const psychologistData = await dbPsychologists.getPsychologistByEmail(dbToken.email);
-        // todo(estellecomment) cookie.js should do the setting
-        res.cookie('token', cookie.getJwtTokenForUser(dbToken.email, psychologistData), cookie.headers);
+        cookie.createAndSetJwtCookie(res, dbToken.email, psychologistData)
         await dbLoginToken.delete(token);
         req.flash('info', `Vous êtes authentifié comme ${dbToken.email}`);
 
@@ -121,6 +120,7 @@ module.exports.postLogin = async function postLogin(req, res) {
 };
 
 module.exports.getLogout = function getLogout (req, res) {
+  cookie.clearJwtCookie(res)
   req.flash('info', `Vous êtes déconnecté.`);
-  res.clearCookie('token').redirect('/psychologue/login');
+  res.redirect('/psychologue/login');
 };

--- a/index.js
+++ b/index.js
@@ -87,7 +87,6 @@ app.use(
     algorithms: ['HS256'],
     getToken: function fromHeaderOrQuerystring (req) {
       if( req.cookies !== undefined ) {
-        console.log('got cookies in request', req.cookies)
         return req.cookies.token;
       } else {
         return null;
@@ -106,7 +105,6 @@ app.use(
 );
 
 app.use((err, req, res, next) => {
-  console.log('generic error handler : ', err)
   if (err.name === 'UnauthorizedError') {
     const psychologueWorkspaceRegexp = new RegExp(/\/psychologue\//, 'g');
     if (psychologueWorkspaceRegexp.test(req.originalUrl)) {

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ app.use(session({
     // httpOnly: the browser cannot read the cookie, only send it to the server.
     httpOnly: true,
     // sameSite : browser only sends the cookie to the site it came from (our site!)
-    sameSite: 'Strict',
+    sameSite: 'Lax',
   },
 }));
 

--- a/index.js
+++ b/index.js
@@ -59,15 +59,7 @@ app.use(session({
   resave: false,
   saveUninitialized: true,
   // We use the same headers for flash cookie as for token cookie.
-  cookie: {
-    // secure: if true, send cookie over https only.
-    // We use false when the server is not https (like localhost) otherwise we break sessions.
-//    secure: config.isSecure, // todo breaks flash messages ??
-    // httpOnly: the browser cannot read the cookie, only send it to the server.
-    httpOnly: true,
-    // sameSite : browser only sends the cookie to the site it came from (our site!)
-    sameSite: 'Lax',
-  },
+  cookie: cookie.headers,
 }));
 
 app.use(flash());

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ app.use(session({
   resave: false,
   saveUninitialized: true,
   // We use the same headers for flash cookie as for token cookie.
-  cookie: cookie.headers,
+//  cookie: cookie.headers,
 }));
 
 app.use(flash());

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const slowDown = require("express-slow-down");
 const cookieParser = require('cookie-parser');
 
 const config = require('./utils/config');
+const cookie = require('./utils/cookie')
 const format = require('./utils/format');
 
 const appName = config.appName;
@@ -51,10 +52,14 @@ app.use('/static/tabulator-tables', express.static(
   path.join(__dirname, 'node_modules/tabulator-tables/dist'))
 );
 
+// This session cookie (connect.sid) is only used for displaying the flash messages.
+// The other session cookie (token) contains the authenticated user session.
 app.use(session({
   secret: config.secret,
   resave: false,
-  saveUninitialized: true
+  saveUninitialized: true,
+  // We use the same headers for flash cookie as for token cookie.
+  cookie: cookie.headers,
 }));
 
 app.use(flash());

--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ app.use(session({
   resave: false,
   saveUninitialized: true,
   // We use the same headers for flash cookie as for token cookie.
+  // (But we could use lower security, this cookie just displays error/success messages.)
   cookie: cookie.headers,
 }));
 

--- a/index.js
+++ b/index.js
@@ -59,7 +59,15 @@ app.use(session({
   resave: false,
   saveUninitialized: true,
   // We use the same headers for flash cookie as for token cookie.
-//  cookie: cookie.headers,
+  cookie: {
+    // secure: if true, send cookie over https only.
+    // We use false when the server is not https (like localhost) otherwise we break sessions.
+//    secure: config.isSecure, // todo breaks flash messages ??
+    // httpOnly: the browser cannot read the cookie, only send it to the server.
+    httpOnly: true,
+    // sameSite : browser only sends the cookie to the site it came from (our site!)
+    sameSite: 'Strict',
+  },
 }));
 
 app.use(flash());
@@ -87,6 +95,7 @@ app.use(
     algorithms: ['HS256'],
     getToken: function fromHeaderOrQuerystring (req) {
       if( req.cookies !== undefined ) {
+        console.log('got cookies in request', req.cookies)
         return req.cookies.token;
       } else {
         return null;
@@ -105,6 +114,7 @@ app.use(
 );
 
 app.use((err, req, res, next) => {
+  console.log('generic error handler : ', err)
   if (err.name === 'UnauthorizedError') {
     const psychologueWorkspaceRegexp = new RegExp(/\/psychologue\//, 'g');
     if (psychologueWorkspaceRegexp.test(req.originalUrl)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "sante-psy",
   "version": "1.0.0",
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "description": "Accompagnement Psychologique pour les étudiants",
   "main": "index.js",
   "scripts": {

--- a/utils/config.js
+++ b/utils/config.js
@@ -1,13 +1,11 @@
 require('dotenv').config();
 
-const isSecure = (process.env.SECURE || 'true') === 'true';
+const hostnameWithProtocol = process.env.HOSTNAME_WITH_PROTOCOL || 'http://localhost:8080'
+const protocol = new URL(hostnameWithProtocol).protocol
 
 module.exports = {
   appName: `Santé Psy Étudiants`,
-  secure: isSecure,
-  protocol: isSecure ? 'https' : 'http',
   activateDebug: (process.env.ACTIVATE_DEBUG_LOG || 'true') === 'false',
-  host: process.env.HOSTNAME,
   port: process.env.PORT || 8080,
   contactEmail: process.env.CONTACT_EMAIL || 'contact-santepsyetudiants@beta.gouv.fr',
   apiToken: process.env.API_TOKEN,
@@ -19,11 +17,13 @@ module.exports = {
   featurePsyList: process.env.FEATURE_PSY_LIST || false,
   featureImportData: process.env.FEATURE_IMPORT_DATA || false,
   featurePsyPages: process.env.FEATURE_PSY_PAGES || false,
-  uuidNamespace: process.env.UUID_NAMESPACE, // used to generate uuid 
+  uuidNamespace: process.env.UUID_NAMESPACE, // used to generate uuid
   secret: process.env.SECRET,
   sessionDurationHours: process.env.SESSION_DURATION_HOURS || '2', // duration in hours
   //mail
-  hostnameWithProtocol: process.env.HOSTNAME_WITH_PROTOCOL || 'http://localhost:8080',
+  hostnameWithProtocol: hostnameWithProtocol,
+  protocol: protocol,
+  isSecure: protocol === 'https:',
   mailDebug: process.env.MAIL_DEBUG === 'true',
   mailService: process.env.MAIL_SERVICE ? process.env.MAIL_SERVICE : null,
   mailHost: process.env.MAIL_SERVICE ? null : process.env.MAIL_HOST,

--- a/utils/cookie.js
+++ b/utils/cookie.js
@@ -4,10 +4,15 @@ const config = require('../utils/config');
 const headers = {
   // secure: if true, send cookie over https only.
   // We use false when the server is not https (like localhost) otherwise we break sessions.
-  secure: false, // todo check that secure breaks redirects config.isSecure,
+  secure: config.isSecure,
   // httpOnly: the browser cannot read the cookie, only send it to the server.
   httpOnly: true,
   // sameSite : browser only sends the cookie to the site it came from (our site!)
+  // We use "Lax" because "Strict" breaks the login process : when you login
+  // by clicking the magic link from gmail, orange mail, or other mail website with specific
+  // referer-policy, the token is not passed correctly to the server (I think it is passed in
+  // the original request, but not in the redirect request to the home page.)
+  // Same problem can happen with CSRF cookie.
   sameSite: 'Lax',
 }
 module.exports.headers = headers

--- a/utils/cookie.js
+++ b/utils/cookie.js
@@ -8,7 +8,7 @@ const headers = {
   // httpOnly: the browser cannot read the cookie, only send it to the server.
   httpOnly: true,
   // sameSite : browser only sends the cookie to the site it came from (our site!)
-  sameSite: 'Strict',
+  sameSite: 'Lax',
 }
 module.exports.headers = headers
 

--- a/utils/cookie.js
+++ b/utils/cookie.js
@@ -1,7 +1,7 @@
 const jwt = require('jsonwebtoken');
 const config = require('../utils/config');
 
-module.exports.headers = {
+const headers = {
   // secure: if true, send cookie over https only.
   // We use false when the server is not https (like localhost) otherwise we break sessions.
   secure: config.isSecure,
@@ -10,6 +10,15 @@ module.exports.headers = {
   // sameSite : browser only sends the cookie to the site it came from (our site!)
   sameSite: 'Strict',
 }
+module.exports.headers = headers
+
+module.exports.createAndSetJwtCookie = (res, email, psychologistData) => {
+  res.cookie('token', getJwtTokenForUser(email, psychologistData), headers);
+}
+
+module.exports.clearJwtCookie = (res) => {
+  res.clearCookie('token')
+}
 
 /**
  * get a json web token to store psychologist data
@@ -17,7 +26,7 @@ module.exports.headers = {
  * @param {*} id
  * @see https://www.ionos.fr/digitalguide/sites-internet/developpement-web/json-web-token-jwt/
  */
-module.exports.getJwtTokenForUser = function getJwtTokenForUser(email, psychologist) {
+const getJwtTokenForUser = function getJwtTokenForUser(email, psychologist) {
   const duration = getSessionDuration();
 
   return jwt.sign(
@@ -29,6 +38,7 @@ module.exports.getJwtTokenForUser = function getJwtTokenForUser(email, psycholog
     { expiresIn: duration }
   );
 };
+module.exports.getJwtTokenForUser = getJwtTokenForUser
 
 function getSessionDuration() {
   return config.sessionDurationHours + ' hours'

--- a/utils/cookie.js
+++ b/utils/cookie.js
@@ -1,5 +1,16 @@
 const jwt = require('jsonwebtoken');
 const config = require('../utils/config');
+
+module.exports.headers = {
+  // secure: if true, send cookie over https only.
+  // We use false when the server is not https (like localhost) otherwise we break sessions.
+  secure: config.isSecure,
+  // httpOnly: the browser cannot read the cookie, only send it to the server.
+  httpOnly: true,
+  // sameSite : browser only sends the cookie to the site it came from (our site!)
+  sameSite: 'Strict',
+}
+
 /**
  * get a json web token to store psychologist data
  * token = encodeBase64(header) + '.' + encodeBase64(payload) + '.' + encodeBase64(signature)

--- a/utils/cookie.js
+++ b/utils/cookie.js
@@ -4,7 +4,7 @@ const config = require('../utils/config');
 const headers = {
   // secure: if true, send cookie over https only.
   // We use false when the server is not https (like localhost) otherwise we break sessions.
-  secure: config.isSecure,
+  secure: false, // todo check that secure breaks redirects config.isSecure,
   // httpOnly: the browser cannot read the cookie, only send it to the server.
   httpOnly: true,
   // sameSite : browser only sends the cookie to the site it came from (our site!)

--- a/utils/email.js
+++ b/utils/email.js
@@ -7,7 +7,7 @@ const mailTransport = nodemailer.createTransport({
   host: config.mailHost,
   port: config.mailPort,
   ignoreTLS: config.ignoreTLS,
-  secure: config.isSecure,
+  secure: false, // todo use config.isSecure
   auth: {
     user: config.auth.user,
     pass: config.auth.pass,


### PR DESCRIPTION
Source : https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies
We use : 
 - Set-Cookie : HttpOnly and Secure
 - SameSite: Lax (strict breaks the login process when clicking a link from certain email clients, see comments in PR)
 
 Note : we have two cookies : one is for sessions, one is for flash messages.
 
 Todo, not in this PR : test logout