### PR TITLE
fix(api): departement field changed from 'value' to 'stringField' 

### DIFF
--- a/test/dossier.json
+++ b/test/dossier.json
@@ -14,7 +14,7 @@
             {
               "id": "Q2hhbXAtMTY1OTUxMw==",
               "label": "Votre département",
-              "value": "14 - Calvados"
+              "stringValue": "14 - Calvados"
             },
             {
               "id": "Q2hhbXAtMTYzMDQxNg==",
@@ -112,7 +112,7 @@
             {
               "id": "Q2hhbXAtMTY1OTUxMw==",
               "label": "Votre département",
-              "value": "14 - Calvados"
+              "stringValue": "14 - Calvados"
             },
             {
               "id": "Q2hhbXAtMTY2MDM0Nw==",

--- a/utils/demarchesSimplifiees.js
+++ b/utils/demarchesSimplifiees.js
@@ -107,7 +107,7 @@ function parseDossierMetadata(dossier) {
   const dossierNumber = getUuidDossierNumber(dossier.number);
   const region = dossier.groupeInstructeur.label;
   const address = getChampValue(dossier.champs, 'Adresse du cabinet');
-  const departement = getChampValue(dossier.champs, 'Votre département', false); // "14 - Calvados"
+  const departement = getChampValue(dossier.champs, 'Votre département'); // "14 - Calvados"
   const phone =  getChampValue(dossier.champs, 'Téléphone du secrétariat');
   const teleconsultation = parseTeleconsultation(
     getChampValue(dossier.champs, 'Proposez-vous de la téléconsultation ?')


### PR DESCRIPTION
## Problème
Le champs département de demarches simplifiées était "value" et est maintenant "stringValue", toutes les données des psychologues ont `null` pour departement

## Solution
Toutes les données seront mise à jour au prochain cron, sans problème :crossed_fingers: