### PR TITLE
Fix broken links in psylist, for real this time

### DIFF
--- a/static/js/build-psy-listing.js
+++ b/static/js/build-psy-listing.js
@@ -13,6 +13,14 @@ setupFilter("departement");
 var psyListElement = document.getElementById("psy-list");
 var psyList = JSON.parse(psyListElement.textContent);
 
+var addPrefixToUrl = (urlCell) => {
+  const url = urlCell.getValue()
+  if (!url.startsWith('http')) {
+    return '//' + url
+  }
+  return url
+}
+
 var table = new Tabulator("#psy-table", {
   data: psyList, //assign data to table
   langs:{ // http://tabulator.info/docs/4.2/localize#setup
@@ -54,7 +62,7 @@ var table = new Tabulator("#psy-table", {
     {title:"📞", field:"phone", sorter:"string", responsive:0, formatter: "link", formatterParams:{labelField:"phone",urlPrefix:"tel:"}},
     {title:"Email", field:"email", sorter:"string", responsive:0, formatter:"link", formatterParams:{labelField:"email",urlPrefix:"mailto://"}},
     {title:"Téléconsultation", field:"teleconsultation",  headerTooltip: "Téléconsultation", responsive:0,sorter:"string", hozAlign:"center",tooltip: "Est ce que le psychologue accepte la téléconsultation ?", formatter:"tickCross"},
-    {title:"Site web", field:"website", sorter:"string", maxWidth:200, responsive:0, formatter:"link", formatterParams:{labelField:"website",target:"_blank"}},
+    {title:"Site web", field:"website", sorter:"string", maxWidth:200, responsive:0, formatter:"link", formatterParams:{labelField:"website",target:"_blank", url: addPrefixToUrl}},
   ],
   headerFilterPlaceholder:"Rechercher un psychologue" // http://tabulator.info/docs/4.9/filter#header
 });


### PR DESCRIPTION
If url starts with http, then display it as is. If not, then add // in front.
Either way, all urls should be clickable and go to the site.