### PR TITLE
Fix : allow multiple filters in psylist

### DIFF
--- a/static/js/build-psy-listing.js
+++ b/static/js/build-psy-listing.js
@@ -1,22 +1,24 @@
 function findFilterForField(fieldName) {
-  // todo no fancy JS
-  var filters = table.getFilters()
-  return filters.find(filter => {
-    return filter.field === fieldName
-  })
+  var filters = table.getFilters();
+  for (var i = 0; i < filter.length; i ++) {
+    if (filters[i].field === fieldName) {
+      return filter;
+    }
+  }
+  return undefined;
 }
 
 function upsertFilterForField(fieldName, newValue) {
-  var filter = findFilterForField(fieldName)
+  var filter = findFilterForField(fieldName);
 
   if (!filter) {
     // New filter : this is the first input into search field by user
-    table.addFilter(fieldName, 'like', newValue)
-    return
+    table.addFilter(fieldName, 'like', newValue);
+    return;
   }
   // Existing filter : update it
-  table.removeFilter(fieldName, 'like', filter.value)
-  table.addFilter(fieldName, 'like', newValue)
+  table.removeFilter(fieldName, 'like', filter.value);
+  table.addFilter(fieldName, 'like', newValue);
 }
 
 var setupFilter = function(fieldName) {

--- a/static/js/build-psy-listing.js
+++ b/static/js/build-psy-listing.js
@@ -1,8 +1,8 @@
 function findFilterForField(fieldName) {
   var filters = table.getFilters();
-  for (var i = 0; i < filter.length; i ++) {
+  for (var i = 0; i < filters.length; i ++) {
     if (filters[i].field === fieldName) {
-      return filter;
+      return filters[i];
     }
   }
   return undefined;

--- a/static/js/build-psy-listing.js
+++ b/static/js/build-psy-listing.js
@@ -1,8 +1,29 @@
+function findFilterForField(fieldName) {
+  // todo no fancy JS
+  var filters = table.getFilters()
+  return filters.find(filter => {
+    return filter.field === fieldName
+  })
+}
+
+function upsertFilterForField(fieldName, newValue) {
+  var filter = findFilterForField(fieldName)
+
+  if (!filter) {
+    // New filter : this is the first input into search field by user
+    table.addFilter(fieldName, 'like', newValue)
+    return
+  }
+  // Existing filter : update it
+  table.removeFilter(fieldName, 'like', filter.value)
+  table.addFilter(fieldName, 'like', newValue)
+}
+
 var setupFilter = function(fieldName) {
   var filterEl = document.getElementById(fieldName + "-filter-value");
   // Trigger setFilter function with correct parameters
   function updateFilter(){
-    table.setFilter(fieldName,'like', filterEl.value);
+    upsertFilterForField(fieldName, filterEl.value);
   }
   filterEl.addEventListener("keyup", updateFilter);
 };


### PR DESCRIPTION
Fix for a bug, where typing into a filter would replace all previous filters, so that you could only filter by one criteria at a time.

tests coming in separate PR