### PR TITLE
Fix/lowercase emails

### DIFF
--- a/controllers/loginController.js
+++ b/controllers/loginController.js
@@ -12,6 +12,7 @@ const config = require('../utils/config');
 module.exports.emailValidators = [
   check('email')
     .isEmail()
+    .toLowerCase()
     .withMessage('Vous devez spécifier un email valide.'),
 ]
 

--- a/test/dossier.json
+++ b/test/dossier.json
@@ -69,7 +69,7 @@
             {
               "id": "Q2hhbXAtMTYwMTE4Ng==",
               "label": "Email de contact",
-              "stringValue": "psychologue.test@beta.gouv.fr"
+              "stringValue": "psychologue.TEST@beta.gouv.fr"
             },
             {
               "id": "Q2hhbXAtMTYzOTUyNA==",
@@ -196,7 +196,7 @@
             "prenom": "Personne"
           },
           "usager": {
-            "email": "loginEmail2@beta.gouv.fr"
+            "email": "loginemail2@beta.gouv.fr"
           }
         }
       ]

--- a/test/helper/clean.js
+++ b/test/helper/clean.js
@@ -4,40 +4,6 @@ const dbPsychologists = require('../../db/psychologists')
 const dbPatients = require('../../db/patients')
 const dbDsApiCursor = require('../../db/dsApiCursor')
 const dbLoginToken = require('../../db/loginToken')
-const rewire = require("rewire");
-const demarchesSimplifiees = rewire('../../utils/demarchesSimplifiees');
-
-
-
-module.exports.testDossierNumber = function getTestDossierNumber() {
-  const getUuidDossierNumber = demarchesSimplifiees.__get__('getUuidDossierNumber');
-  return getUuidDossierNumber(1);
-}
-
-module.exports.psyList = function getPsyList() {
-  return [
-    {
-      dossierNumber: module.exports.testDossierNumber(),
-      firstNames: 'First second',
-      lastName: 'Last',
-      archived : false,
-      state : 'accepte',
-      adeli: "829302942",
-      address: 'SSR CL AL SOLA 66110 MONTBOLO',
-      diploma: "Psychologie clinique de la santé",
-      phone: '0468396600',
-      email: 'psychologue.test@beta.gouv.fr',
-      personalEmail: 'loginemail@beta.gouv.fr',
-      website: 'apas82.mssante.fr',
-      teleconsultation: true,
-      description: "description",
-      // eslint-disable-next-line max-len
-      training: "[\"Connaissance et pratique des outils diagnostic psychologique\",\"Connaissance des troubles psychopathologiques du jeune adulte : dépressions\",\"risques suicidaires\",\"addictions\",\"comportements à risque\",\"troubles alimentaires\",\"décompensation schizophrénique\",\"psychoses émergeantes ainsi qu’une pratique de leur repérage\",\"Connaissance et pratique des dispositifs d’accompagnement psychologique et d’orientation (CMP...)\"]",
-      departement: "14 - Calvados",
-      region: "Normandie",
-      languages: "Français ,Anglais, et Espagnol"
-    }];
-}
 
 module.exports.cleanDataCursor = async function cleanDataCursor() {
   return knex(dbDsApiCursor.dsApiCursorTable).select('*').delete();

--- a/test/helper/clean.js
+++ b/test/helper/clean.js
@@ -27,7 +27,7 @@ module.exports.psyList = function getPsyList() {
       diploma: "Psychologie clinique de la santé",
       phone: '0468396600',
       email: 'psychologue.test@beta.gouv.fr',
-      personalEmail: 'loginEmail@beta.gouv.fr',
+      personalEmail: 'loginemail@beta.gouv.fr',
       website: 'apas82.mssante.fr',
       teleconsultation: true,
       description: "description",

--- a/test/helper/utils.js
+++ b/test/helper/utils.js
@@ -26,8 +26,8 @@ module.exports.psyListFromDS = function psyListFromDS() {
       address: 'SSR CL AL SOLA 66110 MONTBOLO',
       diploma: "Psychologie clinique de la santé",
       phone: '0468396600',
-      email: 'psychologue.test@beta.gouv.fr',
-      personalEmail: 'loginemail@beta.gouv.fr',
+      email: 'psychologue.TEST@beta.gouv.fr', // emails can have uppercase in DS
+      personalEmail: 'loginEmail@beta.gouv.fr', // emails can have uppercase in DS
       website: 'apas82.mssante.fr',
       teleconsultation: true,
       description: "description",

--- a/test/helper/utils.js
+++ b/test/helper/utils.js
@@ -1,7 +1,40 @@
+const rewire = require("rewire");
+const demarchesSimplifiees = rewire('../../utils/demarchesSimplifiees');
+
 module.exports.getCsrfTokenHtml = function getCsrfToken(request) {
   return request.res.text.split('<input type="hidden" name="_csrf" value="')[1].split('">')[0];
 }
 
 module.exports.getCsrfTokenCookie = function getCsrfToken(request) {
   return request.headers['set-cookie'];
+}
+
+module.exports.testDossierNumber = function getTestDossierNumber() {
+  const getUuidDossierNumber = demarchesSimplifiees.__get__('getUuidDossierNumber');
+  return getUuidDossierNumber(1);
+}
+
+module.exports.psyListFromDS = function psyListFromDS() {
+  return [
+    {
+      dossierNumber: module.exports.testDossierNumber(),
+      firstNames: 'First second',
+      lastName: 'Last',
+      archived : false,
+      state : 'accepte',
+      adeli: "829302942",
+      address: 'SSR CL AL SOLA 66110 MONTBOLO',
+      diploma: "Psychologie clinique de la santé",
+      phone: '0468396600',
+      email: 'psychologue.test@beta.gouv.fr',
+      personalEmail: 'loginemail@beta.gouv.fr',
+      website: 'apas82.mssante.fr',
+      teleconsultation: true,
+      description: "description",
+      // eslint-disable-next-line max-len
+      training: "[\"Connaissance et pratique des outils diagnostic psychologique\",\"Connaissance des troubles psychopathologiques du jeune adulte : dépressions\",\"risques suicidaires\",\"addictions\",\"comportements à risque\",\"troubles alimentaires\",\"décompensation schizophrénique\",\"psychoses émergeantes ainsi qu’une pratique de leur repérage\",\"Connaissance et pratique des dispositifs d’accompagnement psychologique et d’orientation (CMP...)\"]",
+      departement: "14 - Calvados",
+      region: "Normandie",
+      languages: "Français ,Anglais, et Espagnol"
+    }];
 }

--- a/test/test-cronDemarchesSimplifiees.js
+++ b/test/test-cronDemarchesSimplifiees.js
@@ -9,6 +9,7 @@ const rewire = require('rewire')
 const cronDemarchesSimplifiees = rewire('../cron_jobs/cronDemarchesSimplifiees');
 const clean = require("./helper/clean");
 const sinon = require('sinon');
+const testUtils = require('./helper/utils')
 
 describe('Import Data from DS to PG', () => {
   let getLatestCursorSavedStub
@@ -32,7 +33,7 @@ describe('Import Data from DS to PG', () => {
     // eslint-disable-next-line max-len
     const cursor = '{"id":1,"cursor":"test","createdAt":"2021-02-19T13:16:45.382Z","updatedAt":"2021-02-19T13:16:45.380Z"}';
     const dsApiData = {
-      psychologists: clean.psyList(),
+      psychologists: testUtils.psyListFromDS(),
       cursor: "test"
     }
     getLatestCursorSavedStub = sinon.stub(dbDsApiCursor, 'getLatestCursorSaved')
@@ -73,7 +74,7 @@ describe('checkForMultipleAcceptedDossiers', () => {
 
   it('should notify if two accepted dossiers for the same person', async () => {
     // insert 2 psychologists, same data except uuid, with accepte state
-    const psyList = clean.psyList()
+    const psyList = testUtils.psyListFromDS()
     psyList[0].state = 'accepte'
     psyList[0].dossierNumber = '27172a9b-5081-4502-9022-b17510ba40a1'
     await dbPsychologists.savePsychologistInPG(psyList)

--- a/test/test-dbPsychologists.js
+++ b/test/test-dbPsychologists.js
@@ -5,9 +5,10 @@ const demarchesSimplifiees = require('../utils/demarchesSimplifiees')
 const knexConfig = require("../knexfile");
 const knex = require("knex")(knexConfig);
 const clean = require('./helper/clean');
+const testUtils = require('./helper/utils')
 
 describe('DB Psychologists', () => {
-  const dossierNumber = clean.testDossierNumber();
+  const dossierNumber = testUtils.testDossierNumber();
   let psyList;
 
   async function testDataPsychologistsExist() {
@@ -21,7 +22,7 @@ describe('DB Psychologists', () => {
   }
 
   beforeEach(async function before() {
-    psyList = clean.psyList();
+    psyList = testUtils.psyListFromDS();
   })
 
   afterEach(async function before() {

--- a/test/test-dbPsychologists.js
+++ b/test/test-dbPsychologists.js
@@ -20,9 +20,11 @@ describe('DB Psychologists', () => {
     return exist;
   }
 
-  //Clean up all data
   beforeEach(async function before() {
     psyList = clean.psyList();
+  })
+
+  afterEach(async function before() {
     await clean.cleanAllPsychologists();
   })
 

--- a/test/test-demarchesSimplifiees.js
+++ b/test/test-demarchesSimplifiees.js
@@ -29,8 +29,8 @@ describe('Demarches Simplifiess', () => {
           address: 'SSR CL AL SOLA 66110 MONTBOLO',
           diploma: "Psychologie clinique de la santé",
           phone: '0468396600',
-          email: 'psychologue.test@beta.gouv.fr',
-          personalEmail: 'loginEmail@beta.gouv.fr',
+          email: 'psychologue.test@beta.gouv.fr', // email should be lowercased
+          personalEmail: 'loginemail@beta.gouv.fr', // personalEmail should be lowercased
           website: 'apas82.mssante.fr',
           teleconsultation: true,
           description: description,
@@ -51,7 +51,7 @@ describe('Demarches Simplifiess', () => {
           phone: '0468396600',
           diploma: "Psychologie clinique de la santé",
           email: 'psychologue.test@beta.gouv.fr',
-          personalEmail: 'loginEmail2@beta.gouv.fr',
+          personalEmail: 'loginemail2@beta.gouv.fr',
           website: 'apas82.mssante.fr',
           teleconsultation: false,
           description: description,

--- a/test/test-loginController.js
+++ b/test/test-loginController.js
@@ -287,6 +287,39 @@ describe('loginController', async function() {
           })
         });
       });
+
+      it('should lowercase email from POST request', function(done) {
+        const emailWithUppercase = 'Prenom.NOM@beta.gouv.fr'
+
+        getAcceptedPsychologistByEmailStub = sinon.stub(dbPsychologists, 'getAcceptedPsychologistByEmail')
+        .returns(Promise.resolve({
+          email: email,
+          state: 'accepte',
+        }));
+
+        chai.request(app)
+        .get(`/psychologue/login`)
+        .end(function(err, res){
+          _csrf = testUtils.getCsrfTokenHtml(res);
+          cookies = testUtils.getCsrfTokenCookie(res);
+          chai.request(app)
+          .post('/psychologue/login')
+          .type('form')
+          .set('cookie',cookies)
+          .send({
+            'email': emailWithUppercase,
+            '_csrf': _csrf,
+          })
+          .end((err, res) => {
+            sinon.assert.called(getAcceptedPsychologistByEmailStub);
+            sinon.assert.calledWith(
+              getAcceptedPsychologistByEmailStub,
+              'prenom.nom@beta.gouv.fr'); // lowercased email
+            done();
+          })
+        });
+      });
+
     });
   });
 })

--- a/utils/demarchesSimplifiees.js
+++ b/utils/demarchesSimplifiees.js
@@ -114,7 +114,7 @@ function parseDossierMetadata(dossier) {
   const archived = dossier.archived;
   const lastName = dossier.demandeur.nom;
   const firstNames = dossier.demandeur.prenom;
-  const personalEmail = dossier.usager.email;
+  const personalEmail = dossier.usager.email.toLowerCase(); // DS login emails should already be lowercase
   const dossierNumber = getUuidDossierNumber(dossier.number);
   const region = dossier.groupeInstructeur.label;
   const address = getChampValue(dossier.champs, 'Adresse du cabinet');
@@ -124,7 +124,7 @@ function parseDossierMetadata(dossier) {
     getChampValue(dossier.champs, 'Proposez-vous de la téléconsultation ?')
   );
   const website =  getChampValue(dossier.champs, 'Site web professionnel (optionnel)');
-  const email =  getChampValue(dossier.champs, 'Email de contact');
+  const email =  getChampValue(dossier.champs, 'Email de contact').toLowerCase();
   const description =  getChampValue(dossier.champs, 'Paragraphe de présentation (optionnel)');
 
   // @TODO comma separated values not reliable


### PR DESCRIPTION
When we import data from DS, lowercase the personalEmail and email. 
When a user logs in, lowercase the email input.

Note : I looked at existing prod data, and personalEmails were already all lowercased (probably because DS forces it). emails were not though. 