### PR TITLE
fix(cookie): use only id for psy

### DIFF
--- a/controllers/loginController.js
+++ b/controllers/loginController.js
@@ -71,7 +71,7 @@ module.exports.getLogin = async function getLogin(req, res) {
 
       if( dbToken !== undefined ) {
         const psychologistData = await dbPsychologists.getAcceptedPsychologistByEmail(dbToken.email);
-        cookie.createAndSetJwtCookie(res, dbToken.email, psychologistData)
+        cookie.createAndSetJwtCookie(res, dbToken.email, psychologistData.dossierNumber)
         await dbLoginToken.delete(token);
         req.flash('info', `Vous êtes authentifié comme ${dbToken.email}`);
         return res.redirect(nextPage);


### PR DESCRIPTION
Lors du login d'un psychologue, nous utilisons seulement pour le fonctionnement de l'application son `id`, cette PR permet de sauvegarder seulement l'ID dans le cookie de session

## Impact
RAS sur les sessions existantes