### PR TITLE
containers: seeding database for dev environement containers first deployment only

### DIFF
--- a/scalingo-dev-seed.sh
+++ b/scalingo-dev-seed.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ "$SEED_FAKE_DATA_DATABASE" = "true" ] ; then
+  echo "Seeding database";
+  npm run migrate;
+  npm run seed;
+else
+  echo "Not seeding database";
+fi

--- a/scalingo.json
+++ b/scalingo.json
@@ -7,6 +7,7 @@
     }
   },
   "scripts": {
+    "first-deploy": "bash scalingo-dev-seed.sh",
     "postdeploy": "npm run migrate"
   }
 }

--- a/test/seed/fake_data.js
+++ b/test/seed/fake_data.js
@@ -9,9 +9,10 @@ const clean = require('../helper/clean');
 exports.seed = function(knex) {
   const psyList = [
     clean.getOnePsy('login@beta.gouv.fr', demarchesSimplifiees.DOSSIER_STATE.accepte, false),
-    clean.getOnePsy('estelle@beta.gouv.fr', demarchesSimplifiees.DOSSIER_STATE.accepte, false),
-    clean.getOnePsy('emeline@beta.gouv.fr', demarchesSimplifiees.DOSSIER_STATE.accepte, false),
-    clean.getOnePsy('paul@beta.gouv.fr', demarchesSimplifiees.DOSSIER_STATE.accepte, false),
+    clean.getOnePsy('estelle.comment@beta.gouv.fr', demarchesSimplifiees.DOSSIER_STATE.accepte, false),
+    clean.getOnePsy('emeline.merliere@beta.gouv.fr', demarchesSimplifiees.DOSSIER_STATE.accepte, false),
+    clean.getOnePsy('paul.leclercq@beta.gouv.fr', demarchesSimplifiees.DOSSIER_STATE.accepte, false),
+    clean.getOnePsy('julien.dauphant@beta.gouv.fr', demarchesSimplifiees.DOSSIER_STATE.accepte, false),
     clean.getOnePsy(`${clean.getRandomInt()}@beta.gouv.fr`, demarchesSimplifiees.DOSSIER_STATE.accepte, false),
     clean.getOnePsy(`${clean.getRandomInt()}@beta.gouv.fr`, demarchesSimplifiees.DOSSIER_STATE.accepte, false),
     clean.getOnePsy(`${clean.getRandomInt()}@beta.gouv.fr`, demarchesSimplifiees.DOSSIER_STATE.accepte, false),


### PR DESCRIPTION
Mettre des données pour le 1er deploiement de chaque review app sur scalingo à base de `npm run seed`

Le script se base sur la présence d'une variable d'environnement :
* `SEED_FAKE_DATA_DATABASE=true`

> first-deploy: Executed after the first deployment of a review app or one-click app.

https://doc.scalingo.com/platform/app/app-manifest#deployment-hooks