### PR TITLE
Db: add deleted status to appointments and patients

### DIFF
--- a/db/appointments.js
+++ b/db/appointments.js
@@ -48,10 +48,6 @@ module.exports.deleteAppointment = async (appointmentId, psychologistId) => {
         updatedAt: date.getDateNowPG()
       })
 
-    if (deletedAppointments[0].deleted === false) {
-      console.error("Appointment not deleted : does not exist or is not allowed")
-      throw new Error("Appointment not deleted : does not exist or is not allowed")
-    }
     return deletedAppointments
   } catch (err) {
     console.error("Erreur de suppression du appointments", err)

--- a/db/appointments.js
+++ b/db/appointments.js
@@ -48,6 +48,8 @@ module.exports.deleteAppointment = async (appointmentId, psychologistId) => {
         updatedAt: date.getDateNowPG()
       })
 
+    console.log(`Appointment id ${appointmentId} deleted by psy id ${psychologistId}`);
+
     return deletedAppointments
   } catch (err) {
     console.error("Erreur de suppression du appointments", err)

--- a/db/appointments.js
+++ b/db/appointments.js
@@ -1,6 +1,7 @@
 const knexConfig = require("../knexfile")
 const knex = require("knex")(knexConfig)
 const dbPatient = require('./patients')
+const date = require("../utils/date");
 
 const appointmentsTable = "appointments"
 module.exports.appointmentsTable = appointmentsTable;
@@ -12,6 +13,7 @@ module.exports.getAppointments = async (psychologistId) => {
     const appointmentArray = await knex.from(dbPatient.patientsTable)
       .innerJoin(`${appointmentsTable}`, `${dbPatient.patientsTable}.id`, `${appointmentsTable}.patientId`)
       .where(`${appointmentsTable}.psychologistId`, psychologistId)
+      .whereNot(`${appointmentsTable}.deleted`, true)
       .orderBy("appointmentDate", "desc")
     return appointmentArray
   } catch (err) {
@@ -22,7 +24,7 @@ module.exports.getAppointments = async (psychologistId) => {
 
 module.exports.insertAppointment = async (appointmentDate, patientId, psychologistId) => {
   try {
-    const insertedArray = await knex(module.exports.appointmentsTable).insert({
+    const insertedArray = await knex(appointmentsTable).insert({
       psychologistId,
       appointmentDate,
       patientId: patientId,
@@ -36,14 +38,17 @@ module.exports.insertAppointment = async (appointmentDate, patientId, psychologi
 
 module.exports.deleteAppointment = async (appointmentId, psychologistId) => {
   try {
-    const deletedAppointments = await knex("appointments")
+    const deletedAppointments = await knex(appointmentsTable)
       .where({
         id: appointmentId,
         psychologistId: psychologistId
       })
-      .del()
-      .returning('*')
-    if (deletedAppointments.length === 0) {
+      .update({
+        deleted: true,
+        updatedAt: date.getDateNowPG()
+      })
+
+    if (deletedAppointments[0].deleted === false) {
       console.error("Appointment not deleted : does not exist or is not allowed")
       throw new Error("Appointment not deleted : does not exist or is not allowed")
     }

--- a/db/patients.js
+++ b/db/patients.js
@@ -1,5 +1,6 @@
 const knexConfig = require("../knexfile")
 const knex = require("knex")(knexConfig)
+const date = require("../utils/date");
 
 module.exports.patientsTable = "patients";
 
@@ -78,6 +79,7 @@ module.exports.updatePatient = async (
         doctorName,
         doctorAddress,
         doctorPhone,
+        updatedAt: date.getDateNowPG()
       })
   } catch (err) {
     console.error("Erreur de modification du patient", err)

--- a/migrations/20210315172126_patient_appointments_deletedstatus.js
+++ b/migrations/20210315172126_patient_appointments_deletedstatus.js
@@ -1,0 +1,23 @@
+/* eslint-disable func-names */
+const dbPatients = require('../db/patients')
+const dbAppointments = require("../db/appointments")
+
+exports.up = function(knex) {
+  return knex.schema.table(dbPatients.patientsTable, function (table) {
+    table.boolean('deleted').defaultTo(false)
+  }).then(() => {
+    return knex.schema.table(dbAppointments.appointmentsTable, function (table) {
+      table.boolean('deleted').defaultTo(false)
+    });
+  });
+};
+
+exports.down = function(knex) {
+  return knex.schema.table(dbPatients.patientsTable, function (table) {
+    table.dropColumn('deleted');
+  }).then(() => {
+    return knex.schema.table(dbAppointments.appointmentsTable, function (table) {
+      table.dropColumn('deleted');
+    });
+  });
+};

--- a/test/helper/clean.js
+++ b/test/helper/clean.js
@@ -2,6 +2,7 @@ const knexConfig = require("../../knexfile");
 const knex = require("knex")(knexConfig);
 const dbPsychologists = require('../../db/psychologists')
 const dbPatients = require('../../db/patients')
+const dbAppointments = require('../../db/appointments')
 const dbDsApiCursor = require('../../db/dsApiCursor')
 const dbLoginToken = require('../../db/loginToken')
 const date = require('../../utils/date');
@@ -80,6 +81,10 @@ module.exports.psyList = function getPsyList(personalEmail = 'loginemail@beta.go
 
 module.exports.cleanDataCursor = async function cleanDataCursor() {
   return knex(dbDsApiCursor.dsApiCursorTable).select('*').delete();
+}
+
+module.exports.cleanDataAppointments = async function cleanDataAppointments() {
+  return knex(dbAppointments.appointmentsTable).select('*').delete();
 }
 
 module.exports.cleanDataToken = async function cleanDataToken() {

--- a/test/test-dbAppointments.js
+++ b/test/test-dbAppointments.js
@@ -15,51 +15,104 @@ describe('DB Appointments', () => {
   })
 
   describe('deleteAppointment', () => {
-
-    it('should change deleted boolean to true', async () => {
+    it('should change deleted boolean to true and update updatedAt field', async () => {
       const psyList = clean.psyList();
       await dbPsychologists.savePsychologistInPG(psyList);
       const psy = await dbPsychologists.getAcceptedPsychologistByEmail(psyList[0].personalEmail)
       const patientToInsert = clean.getOnePatient(psy.dossierNumber)
-      const patient = await dbPatients.insertPatient(patientToInsert.firstNames, patientToInsert.lastName);
-
+      const patient = await dbPatients.insertPatient(
+        patientToInsert.firstNames,
+        patientToInsert.lastName,
+        patientToInsert.INE,
+        patientToInsert.institutionName,
+        patientToInsert.isStudentStatusVerified,
+        patientToInsert.hasPrescription,
+        psy.dossierNumber,
+        patientToInsert.doctorName,
+        patientToInsert.doctorAddress,
+        patientToInsert.doctorPhone,
+      )
       await dbAppointments.insertAppointment(new Date('2021-03-01'), patient.id, psy.dossierNumber)
-      await dbAppointments.deleteAppointment(appointments[0].id, psy.dossierNumber)
 
-      const appointments =  await knex.from(dbAppointments.appointmentsTable)
+      const appointmentsBeforeDelete =  await knex.from(dbAppointments.appointmentsTable)
       .where("psychologistId", psy.dossierNumber)
       .where("patientId", patient.id)
 
-      assert(appointments[0].deleted === true);
-      assert(appointments[0].updatedAt !== undefined);
+      assert(appointmentsBeforeDelete[0].updatedAt === null)
+      assert(appointmentsBeforeDelete[0].deleted === false);
+      await dbAppointments.deleteAppointment(appointmentsBeforeDelete[0].id, psy.dossierNumber)
+
+      const appointmentsAfterDelete =  await knex.from(dbAppointments.appointmentsTable)
+      .where("psychologistId", psy.dossierNumber)
+      .where("patientId", patient.id)
+      assert(appointmentsAfterDelete[0].deleted === true);
+      assert(appointmentsAfterDelete[0].updatedAt !== null);
     });
   });
 
   describe('getAppointments', () => {
-    it('should return not deleted appointments for psy id', async () => {
+    it('should only return not deleted appointments for psy id', async () => {
       const psyList = clean.psyList();
       await dbPsychologists.savePsychologistInPG(psyList);
       const psy = await dbPsychologists.getAcceptedPsychologistByEmail(psyList[0].personalEmail)
-      const patient = await dbPatients.insertPatient(clean.getOnePatient(psy.dossierNumber));
-      await dbAppointments.insertAppointment(new Date('2021-03-01'), patient.id, psy.dossierNumber)
-      const appointments = await dbAppointments.getAppointments(psy.dossierNumber);
-      console.log("appointments", appointments)
-      await dbAppointments.deleteAppointment(appointments[0].id, psy.dossierNumber)
+      const patientToInsert = clean.getOnePatient(psy.dossierNumber)
+      const patient = await dbPatients.insertPatient(
+        patientToInsert.firstNames,
+        patientToInsert.lastName,
+        patientToInsert.INE,
+        patientToInsert.institutionName,
+        patientToInsert.isStudentStatusVerified,
+        patientToInsert.hasPrescription,
+        psy.dossierNumber,
+        patientToInsert.doctorName,
+        patientToInsert.doctorAddress,
+        patientToInsert.doctorPhone,
+      )
+      const toDelete = await dbAppointments.insertAppointment(new Date('2021-03-01'), patient.id, psy.dossierNumber)
+      await dbAppointments.insertAppointment(new Date('2021-03-02'), patient.id, psy.dossierNumber)
+      await dbAppointments.insertAppointment(new Date('2021-03-03'), patient.id, psy.dossierNumber)
+
+      await dbAppointments.deleteAppointment(toDelete.id, psy.dossierNumber)
+
       const output = await dbAppointments.getAppointments(psy.dossierNumber);
 
-      assert(output.length === 0);
+      assert(output.length === 2);
+      assert(output[0].deleted === false);
+      assert(output[1].deleted === false);
     });
 
-    it('should return not deleted appointments for psy id', async () => {
-      const psyList = clean.psyList();
-      await dbPsychologists.savePsychologistInPG(psyList);
+    it('should only return psy id appointments', async () => {
+      const psyList = clean.psyList(); //@TODO add another psy
+      let anotherPsy = Object.assign({}, psyList[0]);
+      anotherPsy.dossierNumber = "b2e447cd-2d57-4f83-8884-ab05a2633644";
+
+      await dbPsychologists.savePsychologistInPG([psyList[0], anotherPsy]);
       const psy = await dbPsychologists.getAcceptedPsychologistByEmail(psyList[0].personalEmail)
-      const patient = await dbPatients.insertPatient(clean.getOnePatient(psy.dossierNumber));
-      await dbAppointments.insertAppointment(new Date('2021-03-01'), patient.id, psy.dossierNumber)
-      const appointments = await dbAppointments.getAppointments(psy.dossierNumber);
-      await dbAppointments.deleteAppointment(appointments[0].id, psy.dossierNumber)
+      const patientToInsert = clean.getOnePatient(psy.dossierNumber)
+      const patient = await dbPatients.insertPatient(
+        patientToInsert.firstNames,
+        patientToInsert.lastName,
+        patientToInsert.INE,
+        patientToInsert.institutionName,
+        patientToInsert.isStudentStatusVerified,
+        patientToInsert.hasPrescription,
+        psy.dossierNumber,
+        patientToInsert.doctorName,
+        patientToInsert.doctorAddress,
+        patientToInsert.doctorPhone,
+      )
+
+      await dbAppointments.insertAppointment(new Date('2021-03-02'), patient.id, psy.dossierNumber)
+      await dbAppointments.insertAppointment(new Date('2021-03-03'), patient.id, psy.dossierNumber)
+      await dbAppointments.insertAppointment(new Date('2021-03-04'), patient.id, psy.dossierNumber)
+      await dbAppointments.insertAppointment(new Date('2021-03-03'), patient.id, anotherPsy.dossierNumber)
+
       const output = await dbAppointments.getAppointments(psy.dossierNumber);
-      assert(output === undefined);
+
+      assert(output.length === 3);
+      assert(output[0].psychologistId === psy.dossierNumber);
+      assert(output[1].psychologistId === psy.dossierNumber);
+      assert(output[2].psychologistId === psy.dossierNumber);
     });
   });
 });

--- a/test/test-dbAppointments.js
+++ b/test/test-dbAppointments.js
@@ -1,0 +1,65 @@
+require('dotenv').config();
+const knexConfig = require("../knexfile")
+const knex = require("knex")(knexConfig)
+const assert = require('chai').assert;
+const dbAppointments = require('../db/appointments')
+const dbPatients = require('../db/patients')
+const dbPsychologists = require('../db/psychologists')
+const clean = require('./helper/clean');
+
+describe('DB Appointments', () => {
+  beforeEach(async function before() {
+    await clean.cleanAllPatients();
+    await clean.cleanAllPsychologists();
+    await clean.cleanDataAppointments();
+  })
+
+  describe('deleteAppointment', () => {
+
+    it('should change deleted boolean to true', async () => {
+      const psyList = clean.psyList();
+      await dbPsychologists.savePsychologistInPG(psyList);
+      const psy = await dbPsychologists.getAcceptedPsychologistByEmail(psyList[0].personalEmail)
+      const patientToInsert = clean.getOnePatient(psy.dossierNumber)
+      const patient = await dbPatients.insertPatient(patientToInsert.firstNames, patientToInsert.lastName);
+
+      await dbAppointments.insertAppointment(new Date('2021-03-01'), patient.id, psy.dossierNumber)
+      await dbAppointments.deleteAppointment(appointments[0].id, psy.dossierNumber)
+
+      const appointments =  await knex.from(dbAppointments.appointmentsTable)
+      .where("psychologistId", psy.dossierNumber)
+      .where("patientId", patient.id)
+
+      assert(appointments[0].deleted === true);
+      assert(appointments[0].updatedAt !== undefined);
+    });
+  });
+
+  describe('getAppointments', () => {
+    it('should return not deleted appointments for psy id', async () => {
+      const psyList = clean.psyList();
+      await dbPsychologists.savePsychologistInPG(psyList);
+      const psy = await dbPsychologists.getAcceptedPsychologistByEmail(psyList[0].personalEmail)
+      const patient = await dbPatients.insertPatient(clean.getOnePatient(psy.dossierNumber));
+      await dbAppointments.insertAppointment(new Date('2021-03-01'), patient.id, psy.dossierNumber)
+      const appointments = await dbAppointments.getAppointments(psy.dossierNumber);
+      console.log("appointments", appointments)
+      await dbAppointments.deleteAppointment(appointments[0].id, psy.dossierNumber)
+      const output = await dbAppointments.getAppointments(psy.dossierNumber);
+
+      assert(output.length === 0);
+    });
+
+    it('should return not deleted appointments for psy id', async () => {
+      const psyList = clean.psyList();
+      await dbPsychologists.savePsychologistInPG(psyList);
+      const psy = await dbPsychologists.getAcceptedPsychologistByEmail(psyList[0].personalEmail)
+      const patient = await dbPatients.insertPatient(clean.getOnePatient(psy.dossierNumber));
+      await dbAppointments.insertAppointment(new Date('2021-03-01'), patient.id, psy.dossierNumber)
+      const appointments = await dbAppointments.getAppointments(psy.dossierNumber);
+      await dbAppointments.deleteAppointment(appointments[0].id, psy.dossierNumber)
+      const output = await dbAppointments.getAppointments(psy.dossierNumber);
+      assert(output === undefined);
+    });
+  });
+});


### PR DESCRIPTION
Pour garder une trace en cas d'audit nous ajoutons le champs booléan `deleted` dans la BD pour appointments et patients