### PR TITLE
legal: remove phone number - none available

### DIFF
--- a/views/legalNotice.ejs
+++ b/views/legalNotice.ejs
@@ -20,7 +20,6 @@
       <p>
         Coordonnées :<br>
         Adresse : DINUM, 20 avenue de Ségur, 75007 Paris<br>
-        Tel. accueil : 01.71.21.01.70<br>
         SIRET : 12000101100010 (secrétariat général du gouvernement)<br>
         SIREN : 120 001 011
       </p>


### PR DESCRIPTION
Enlève le numéro de téléphone de la DINUM, pour éviter que l'accueil ne reçoivent des appels non désirés (contact par email priviliègié)