### PR TITLE
ops: add log alert system 'sentry' to monitor production

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -30,6 +30,10 @@ TZ=utc
 # Session Token duration validity
 SESSION_DURATION_HOURS=2
 
+# See https://sentry.io/betagouv-f7/sante-psy-prod/
+# SENTRY_DNS = 
+
+
 # Hostname : the links sent in email will use this hostname. Default is http://localhost:$PORT
 HOSTNAME_WITH_PROTOCOL="http://localhost:8080"
 

--- a/cron_jobs/cron.js
+++ b/cron_jobs/cron.js
@@ -1,6 +1,9 @@
 const cron = require('cron');
 const cronDemarchesSimplifiees  = require("./cronDemarchesSimplifiees")
 const config = require('../utils/config');
+const sentry = require('../utils/sentry');
+
+sentry.initCaptureConsole();
 
 const jobs = [{
   cronTime: "*/5 * * * *", // every 5 minutes

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ const expressSanitizer = require('express-sanitizer');
 const path = require('path');
 const helmet = require('helmet')
 const flash = require('connect-flash');
-const session = require('express-session');
 const expressJWT = require('express-jwt');
 const rateLimit = require("express-rate-limit");
 const slowDown = require("express-slow-down");
@@ -16,6 +15,7 @@ const csrf = require('csurf');
 
 const config = require('./utils/config');
 const format = require('./utils/format');
+const sentry = require('./utils/sentry');
 
 const appName = config.appName;
 const appDescription = 'Accompagnement psychologique pour les étudiants';
@@ -135,7 +135,7 @@ app.use((err, req, res, next) => {
         `Vous n'êtes pas identifié pour accéder à cette page ou votre accès n'est plus valide\
          - la connexion est valide durant ${config.sessionDurationHours} heures`,
       );
-      console.debug("No token - redirect to login");
+      console.log("No token - redirect to login");
       return res.redirect(`/psychologue/login`);
     } else {
       req.flash('error', "Cette page n'existe pas.");
@@ -237,6 +237,9 @@ app.get('*', function redirect404(req, res){
     return res.redirect(`/psychologue/mes-seances`);
   }
 });
+
+
+sentry.initCaptureConsoleWithHandler(app);
 
 module.exports = app.listen(config.port, () => {
   console.log(`${appName} listening at http://localhost:${config.port}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "sante-psy",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
@@ -9,6 +9,9 @@
       "license": "MIT",
       "dependencies": {
         "@gouvfr/all": "^0.4.0",
+        "@sentry/integrations": "^6.2.2",
+        "@sentry/node": "^6.2.2",
+        "@sentry/tracing": "^6.2.2",
         "body-parser": "^1.19.0",
         "connect-flash": "^0.1.1",
         "cookie-parser": "^1.4.5",
@@ -782,6 +785,122 @@
         "node": ">=8"
       }
     },
+    "node_modules/@sentry/core": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.2.2.tgz",
+      "integrity": "sha512-qqWbvvXtymfXh7N5eEvk97MCnMURuyFIgqWdVD4MQM6yIfDCy36CyGfuQ3ViHTLZGdIfEOhLL9/f4kzf1RzqBA==",
+      "dependencies": {
+        "@sentry/hub": "6.2.2",
+        "@sentry/minimal": "6.2.2",
+        "@sentry/types": "6.2.2",
+        "@sentry/utils": "6.2.2",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/hub": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.2.2.tgz",
+      "integrity": "sha512-VR6uQGRYt6RP633FHShlSLj0LUKGVrlTeSlwCoooWM5FR9lmi6akAaweuxpG78/kZvXrAWpjX6/nuYwHKGwzGA==",
+      "dependencies": {
+        "@sentry/types": "6.2.2",
+        "@sentry/utils": "6.2.2",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/integrations": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.2.2.tgz",
+      "integrity": "sha512-B7oaQD3+dVZpgQIOWK19F12fxHKcU7AJXdcjw/gHRMLulLTYjGSFwgVS/zdaC+4W/zGO/HpZjFqqXqqRP9ipEg==",
+      "dependencies": {
+        "@sentry/types": "6.2.2",
+        "@sentry/utils": "6.2.2",
+        "localforage": "^1.8.1",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/minimal": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.2.2.tgz",
+      "integrity": "sha512-l0IgoGQgg1lTd4qDU8bQn25sbZBg8PwIHfuTLbGMlRr1flDXHOM1UXajWK/UKbAPelnU7M2JBSVzgl7PwjprzA==",
+      "dependencies": {
+        "@sentry/hub": "6.2.2",
+        "@sentry/types": "6.2.2",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.2.2.tgz",
+      "integrity": "sha512-HmQJx3C2C8cj3oC9piFuXJ7NzM+jW15u4RKcRXxJUgHNbZPR/RsScOOi5TbNZAO4k3A8fSJQD8aPj+dbPx/j/Q==",
+      "dependencies": {
+        "@sentry/core": "6.2.2",
+        "@sentry/hub": "6.2.2",
+        "@sentry/types": "6.2.2",
+        "@sentry/utils": "6.2.2",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@sentry/tracing": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.2.2.tgz",
+      "integrity": "sha512-mAkPoqtofNfka/u9rOVVDQPaEoTmr0AQh654g9ZqsaqsOJLKjB4FDLVNubWs90fjeKqHiYkI3ZHPak2TzHBPkw==",
+      "dependencies": {
+        "@sentry/hub": "6.2.2",
+        "@sentry/minimal": "6.2.2",
+        "@sentry/types": "6.2.2",
+        "@sentry/utils": "6.2.2",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.2.2.tgz",
+      "integrity": "sha512-Y/1sRtw3a5JU4YdNBig8lLSVJ1UdYtuge+QP1CVLcLSAbq07Ok1bvF+Z+BlNcnHqle2Fl8aKuryG5Yu86enOyQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.2.2.tgz",
+      "integrity": "sha512-qaee6X6VDNZ8HeO83/veaKw0KuhDE7j1R+Yryme3PywFzsoTzutDrEQjb7gvcHAhBaAYX8IHUBHgxcFI9BxI+w==",
+      "dependencies": {
+        "@sentry/types": "6.2.2",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -907,6 +1026,38 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
       "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
       "dev": true
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agent-base/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
@@ -3729,6 +3880,39 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
     "node_modules/husky": {
       "version": "5.0.9",
       "resolved": "https://registry.npmjs.org/husky/-/husky-5.0.9.tgz",
@@ -3774,6 +3958,11 @@
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "dev": true
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -4696,6 +4885,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/liftoff": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-3.1.0.tgz",
@@ -4712,6 +4909,14 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.9.0.tgz",
+      "integrity": "sha512-rR1oyNrKulpe+VM9cYmcFn6tsHuokyVHFaCM3+osEmxaHTbEk8oQu6eGDfS6DQLWi/N67XRmB8ECG37OES368g==",
+      "dependencies": {
+        "lie": "3.1.1"
       }
     },
     "node_modules/locate-path": {
@@ -4867,6 +5072,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -7926,8 +8136,7 @@
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",
@@ -9274,6 +9483,97 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
+    "@sentry/core": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.2.2.tgz",
+      "integrity": "sha512-qqWbvvXtymfXh7N5eEvk97MCnMURuyFIgqWdVD4MQM6yIfDCy36CyGfuQ3ViHTLZGdIfEOhLL9/f4kzf1RzqBA==",
+      "requires": {
+        "@sentry/hub": "6.2.2",
+        "@sentry/minimal": "6.2.2",
+        "@sentry/types": "6.2.2",
+        "@sentry/utils": "6.2.2",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.2.2.tgz",
+      "integrity": "sha512-VR6uQGRYt6RP633FHShlSLj0LUKGVrlTeSlwCoooWM5FR9lmi6akAaweuxpG78/kZvXrAWpjX6/nuYwHKGwzGA==",
+      "requires": {
+        "@sentry/types": "6.2.2",
+        "@sentry/utils": "6.2.2",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/integrations": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-6.2.2.tgz",
+      "integrity": "sha512-B7oaQD3+dVZpgQIOWK19F12fxHKcU7AJXdcjw/gHRMLulLTYjGSFwgVS/zdaC+4W/zGO/HpZjFqqXqqRP9ipEg==",
+      "requires": {
+        "@sentry/types": "6.2.2",
+        "@sentry/utils": "6.2.2",
+        "localforage": "^1.8.1",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.2.2.tgz",
+      "integrity": "sha512-l0IgoGQgg1lTd4qDU8bQn25sbZBg8PwIHfuTLbGMlRr1flDXHOM1UXajWK/UKbAPelnU7M2JBSVzgl7PwjprzA==",
+      "requires": {
+        "@sentry/hub": "6.2.2",
+        "@sentry/types": "6.2.2",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/node": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-6.2.2.tgz",
+      "integrity": "sha512-HmQJx3C2C8cj3oC9piFuXJ7NzM+jW15u4RKcRXxJUgHNbZPR/RsScOOi5TbNZAO4k3A8fSJQD8aPj+dbPx/j/Q==",
+      "requires": {
+        "@sentry/core": "6.2.2",
+        "@sentry/hub": "6.2.2",
+        "@sentry/types": "6.2.2",
+        "@sentry/utils": "6.2.2",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        }
+      }
+    },
+    "@sentry/tracing": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-6.2.2.tgz",
+      "integrity": "sha512-mAkPoqtofNfka/u9rOVVDQPaEoTmr0AQh654g9ZqsaqsOJLKjB4FDLVNubWs90fjeKqHiYkI3ZHPak2TzHBPkw==",
+      "requires": {
+        "@sentry/hub": "6.2.2",
+        "@sentry/minimal": "6.2.2",
+        "@sentry/types": "6.2.2",
+        "@sentry/utils": "6.2.2",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.2.2.tgz",
+      "integrity": "sha512-Y/1sRtw3a5JU4YdNBig8lLSVJ1UdYtuge+QP1CVLcLSAbq07Ok1bvF+Z+BlNcnHqle2Fl8aKuryG5Yu86enOyQ=="
+    },
+    "@sentry/utils": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.2.2.tgz",
+      "integrity": "sha512-qaee6X6VDNZ8HeO83/veaKw0KuhDE7j1R+Yryme3PywFzsoTzutDrEQjb7gvcHAhBaAYX8IHUBHgxcFI9BxI+w==",
+      "requires": {
+        "@sentry/types": "6.2.2",
+        "tslib": "^1.9.3"
+      }
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -9384,6 +9684,29 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
       "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
       "dev": true
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "aggregate-error": {
       "version": "3.1.0",
@@ -11629,6 +11952,30 @@
         }
       }
     },
+    "https-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "husky": {
       "version": "5.0.9",
       "resolved": "https://registry.npmjs.org/husky/-/husky-5.0.9.tgz",
@@ -11659,6 +12006,11 @@
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha1-SMptcvbGo68Aqa1K5odr44ieKwk=",
       "dev": true
+    },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -12389,6 +12741,14 @@
         "type-check": "~0.4.0"
       }
     },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+      "requires": {
+        "immediate": "~3.0.5"
+      }
+    },
     "liftoff": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-3.1.0.tgz",
@@ -12402,6 +12762,14 @@
         "object.map": "^1.0.0",
         "rechoir": "^0.6.2",
         "resolve": "^1.1.7"
+      }
+    },
+    "localforage": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.9.0.tgz",
+      "integrity": "sha512-rR1oyNrKulpe+VM9cYmcFn6tsHuokyVHFaCM3+osEmxaHTbEk8oQu6eGDfS6DQLWi/N67XRmB8ECG37OES368g==",
+      "requires": {
+        "lie": "3.1.1"
       }
     },
     "locate-path": {
@@ -12535,6 +12903,11 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
+    },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -14956,8 +15329,7 @@
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tsscmp": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
   "homepage": "https://github.com/betagouv/sante-psy#readme",
   "dependencies": {
     "@gouvfr/all": "^0.4.0",
+    "@sentry/integrations": "^6.2.2",
+    "@sentry/node": "^6.2.2",
+    "@sentry/tracing": "^6.2.2",
     "body-parser": "^1.19.0",
     "connect-flash": "^0.1.1",
     "cookie-parser": "^1.4.5",

--- a/utils/config.js
+++ b/utils/config.js
@@ -21,6 +21,7 @@ module.exports = {
   databaseUrl: process.env.DATABASE_URL,
   demarchesSimplifieesId: process.env.DEMARCHES_SIMPLIFIEES_ID,
   demarchesSimplifieesUrl: process.env.DEMARCHES_SIMPLIFIEES_URL,
+  sentryDNS: process.env.SENTRY_DNS || false,
   featurePsyList: process.env.FEATURE_PSY_LIST || false,
   featureImportData: process.env.FEATURE_IMPORT_DATA || false,
   featurePsyPages: process.env.FEATURE_PSY_PAGES || false,

--- a/utils/sentry.js
+++ b/utils/sentry.js
@@ -1,0 +1,39 @@
+const Sentry = require("@sentry/node");
+const sentryIntegrations = require("@sentry/integrations");
+
+const config = require('./config');
+
+/**
+ * 
+ * @see https://sentry.io/betagouv-f7/sante-psy-prod/getting-started/node-express/
+ */
+module.exports.initCaptureConsole = function init() {
+  const logLevel =  ['error'];
+  console.log(`Initializing Sentry for log level "${logLevel}" and config: ${config.sentryDNS}`);
+  Sentry.init({
+    dsn: config.sentryDNS,
+    //https://docs.sentry.io/platforms/javascript/configuration/integrations/plugin/#captureconsole
+    integrations: [
+      new sentryIntegrations.CaptureConsole({levels: logLevel}),
+    ],
+  });
+}
+
+/**
+ * 
+ * @param {*} app 
+ */
+module.exports.initCaptureConsoleWithHandler = function initCaptureConsoleWithHandler(app) {
+  if( config.sentryDNS ) {
+    this.init(config.sentryDNS);
+
+    // RequestHandler creates a separate execution context using domains, so that every
+    // transaction/span/breadcrumb is attached to its own Hub instance
+    app.use(Sentry.Handlers.requestHandler());
+
+    // The error handler must be before any other error middleware and after all controllers
+    app.use(Sentry.Handlers.errorHandler());
+  } else {
+    console.log("Sentry was not initialized as SENTRY_DNS env variable is missing");
+  }
+}

--- a/utils/sentry.js
+++ b/utils/sentry.js
@@ -19,10 +19,6 @@ module.exports.initCaptureConsole = function init() {
   });
 }
 
-/**
- * 
- * @param {*} app 
- */
 module.exports.initCaptureConsoleWithHandler = function initCaptureConsoleWithHandler(app) {
   if( config.sentryDNS ) {
     this.init(config.sentryDNS);


### PR DESCRIPTION
# But
Permettre la surveillance d'erreurs côté backend avec le service Sentry
Toutes les messages reçus par la fonction `console.error` sont envoyées à Sentry

## Configuration

https://sentry.io/settings/betagouv-f7/projects/sante-psy-prod/keys/

## Execution
Si la variable `SENTRY_DNS` est défini avec :
> Initializing Sentry for log level error and config: https:

Sinon

> Sentry was not initialized as SENTRY_DNS env variable is missing

## Tests
Testé avec `npm start` et `node cron_jobs/cron.js`  avec des données remontées vers Sentry :heavy_check_mark: 
