### PR TITLE
fix(sentry): wrong method called

### DIFF
--- a/utils/sentry.js
+++ b/utils/sentry.js
@@ -7,7 +7,7 @@ const config = require('./config');
  * 
  * @see https://sentry.io/betagouv-f7/sante-psy-prod/getting-started/node-express/
  */
-module.exports.initCaptureConsole = function init() {
+module.exports.initCaptureConsole = function initCaptureConsole() {
   const logLevel =  ['error'];
   console.log(`Initializing Sentry for log level "${logLevel}" and config: ${config.sentryDNS}`);
   Sentry.init({
@@ -21,7 +21,7 @@ module.exports.initCaptureConsole = function init() {
 
 module.exports.initCaptureConsoleWithHandler = function initCaptureConsoleWithHandler(app) {
   if( config.sentryDNS ) {
-    this.init(config.sentryDNS);
+    this.initCaptureConsole(config.sentryDNS);
 
     // RequestHandler creates a separate execution context using domains, so that every
     // transaction/span/breadcrumb is attached to its own Hub instance


### PR DESCRIPTION
Suite à une refacto, une methode qui n'existait plus se faisait appeller ce qui empêchait le deploiement de l'application:

`TypeError: this.init is not a function`

## Corrections faites liées
* ajout du notifications de scalingo par email dans le cas d'échec de deploiement