### PR TITLE
refacto: login token from 256 base 64 to 26 using hex

### DIFF
--- a/controllers/loginController.js
+++ b/controllers/loginController.js
@@ -17,7 +17,7 @@ module.exports.emailValidators = [
 ]
 
 function generateToken() {
-  return crypto.randomBytes(256).toString('base64');
+  return crypto.randomBytes(26).toString('hex');
 }
 
 async function sendLoginEmail(email, loginUrl, token) {

--- a/controllers/loginController.js
+++ b/controllers/loginController.js
@@ -16,8 +16,11 @@ module.exports.emailValidators = [
     .withMessage('Vous devez spécifier un email valide.'),
 ]
 
+/**
+ * @see https://www.ssi.gouv.fr/administration/precautions-elementaires/calculer-la-force-dun-mot-de-passe/
+ */
 function generateToken() {
-  return crypto.randomBytes(26).toString('hex');
+  return crypto.randomBytes(64).toString('hex');
 }
 
 async function sendLoginEmail(email, loginUrl, token) {

--- a/test/test-loginController.js
+++ b/test/test-loginController.js
@@ -28,7 +28,7 @@ describe('loginController', async function() {
     it('should generate a token', function() {
       const generateToken = loginController.__get__('generateToken');
       const output = generateToken("localhost:8080");
-      output.length.should.equal(52);
+      output.length.should.equal(128);
     })
 
     it('should generate a different token everytime the function is called', function() {

--- a/test/test-loginController.js
+++ b/test/test-loginController.js
@@ -28,7 +28,7 @@ describe('loginController', async function() {
     it('should generate a token', function() {
       const generateToken = loginController.__get__('generateToken');
       const output = generateToken("localhost:8080");
-      output.length.should.equal(344);
+      output.length.should.equal(52);
     })
 
     it('should generate a different token everytime the function is called', function() {


### PR DESCRIPTION
## Motivation
L'email de login contient un token de 362 caractères en base 64 qui peut causer des problèmes avec certains fournisseurs d'email (outlook safelink), cette PR raccourcie ce token à 52 caractères hexadécimal

Bonus:  Cela facilite le copier coller du token à partir de l'email dans le cas où on ne peut pas cliquer sur les liens proposés

## Tests
La coute durée de vie (1h) du token ainsi que sa suppresion une fois utilsé sont la sécurité de ce système :lock: 

Demarches simplifiées utilisent également de l'hexadécimal pour son token de connexion

## A lire
https://www.ssi.gouv.fr/administration/precautions-elementaires/calculer-la-force-dun-mot-de-passe/