### PR TITLE
fix: render reimbursement page even when no db is available

### DIFF
--- a/controllers/reimbursementController.js
+++ b/controllers/reimbursementController.js
@@ -9,8 +9,11 @@ module.exports.reimbursement = async function reimbursement(req, res) {
   try {
     universityList = await dbUniversities.getUniversities()
     if (!universityList || universityList.length === 0) {
-      throw new Error('No universities in db')
+      req.flash('error', `Les universités n'ont pas pu être récupérées. Veuillez réessayer plus tard.`)
+      console.error('No universities in db');
     }
+
+    // used to place "-- nothing yet" in first position
     universityList.sort((a, b) => {
       if(a.name < b.name) { return -1; }
       if(a.name > b.name) { return 1; }

--- a/controllers/reimbursementController.js
+++ b/controllers/reimbursementController.js
@@ -8,10 +8,6 @@ module.exports.reimbursement = async function reimbursement(req, res) {
   let universityList = []
   try {
     universityList = await dbUniversities.getUniversities()
-    if (!universityList || universityList.length === 0) {
-      req.flash('error', `Les universités n'ont pas pu être récupérées. Veuillez réessayer plus tard.`)
-      console.error('No universities in db');
-    }
 
     // used to place "-- nothing yet" in first position
     universityList.sort((a, b) => {

--- a/views/partials/selectPayingUniversity.ejs
+++ b/views/partials/selectPayingUniversity.ejs
@@ -8,7 +8,10 @@
       Elle remboursera pour tous les étudiants, qu'ils appartiennent à cette université ou une autre.
     </div>
   </div>
-  <% if (!!universities && universities.length > 0) { %> <!-- Only display current convention if there are universities -->
+  <% if (!universities || universities.length === 0) { %>
+    <!-- Only display current convention if there are universities -->
+    A venir bientôt : dites-nous où vous en êtes du conventionnement pour que nous puissions vous aider au besoin.
+  <% } else { %>
     <div id="current-university" <% if (showForm) { %> hidden <% } %>>
       <div><b>Statut de ma convention :</b></div>
       <div>

--- a/views/partials/selectPayingUniversity.ejs
+++ b/views/partials/selectPayingUniversity.ejs
@@ -8,85 +8,87 @@
       Elle remboursera pour tous les étudiants, qu'ils appartiennent à cette université ou une autre.
     </div>
   </div>
-  <div id="current-university" <% if (showForm) { %> hidden <% } %>>
-    <div><b>Statut de ma convention :</b></div>
-    <div>
-      Je suis rattaché à l'université de <b><%= currentConvention.universityName %></b>.
-    </div>
-    <div class="rf-mb-2w">
-      La convention
-      <% if (currentConvention.isConventionSigned) { %>
-        est <b>signée</b>.
-      <% } else { %>
-        n'est <b>pas encore signée</b>.
-      <% } %>
-    </div>
-    <div>
-      <div>Un changement de statut ? Tenez-nous au courant !</div>
-      <button id="change-current-university-button" class="rf-btn rf-fi-edit-line rf-btn--icon-left">
-        Modifier le statut
-      </button>
-    </div>
-  </div>
-
-  <div id="change-current-university-form" <% if (!showForm) { %> hidden <% } %>>
-      <% if (currentConvention.universityId) { %>
-        <h4>Modifier le statut de ma convention</h4>
-      <% } %>
-      <form action="/psychologue/api/renseigner-convention" method="POST">
-      <input type="hidden" name="_csrf" value="<%= _csrf  %>">
-
-      <div class="rf-select-group">
-        <label class="rf-label" for="university">
-          Quelle université vous a contacté pour signer la convention ?
-          <span class="red-text">*</span>
-        </label>
-        <select class="rf-select" id="university" name="university" required>
-          <% if (!currentConvention.universityid) { %>
-            <option value="" selected disabled hidden>- Cliquez pour choisir -</option>
-          <% } %>
-          <% universities.forEach(function(university) { %>
-            <option
-              value="<%= university.id %>"
-              <% if (university.id === currentConvention.universityId) { %> selected <% } %>
-            >
-              <%= university.name %>
-            </option>
-          <% }) %>
-        </select>
+  <% if (!!universities && universities.length > 0) { %> <!-- Only display current convention if there are universities -->
+    <div id="current-university" <% if (showForm) { %> hidden <% } %>>
+      <div><b>Statut de ma convention :</b></div>
+      <div>
+        Je suis rattaché à l'université de <b><%= currentConvention.universityName %></b>.
       </div>
+      <div class="rf-mb-2w">
+        La convention
+        <% if (currentConvention.isConventionSigned) { %>
+          est <b>signée</b>.
+        <% } else { %>
+          n'est <b>pas encore signée</b>.
+        <% } %>
+      </div>
+      <div>
+        <div>Un changement de statut ? Tenez-nous au courant !</div>
+        <button id="change-current-university-button" class="rf-btn rf-fi-edit-line rf-btn--icon-left">
+          Modifier le statut
+        </button>
+      </div>
+    </div>
 
-      <div class="rf-form-group">
-        <fieldset class="rf-fieldset">
-          <legend class="rf-label rf-mb-1w"> <!-- we don't use rf-fieldset__legend, it looks different -->
-            Avez-vous déjà signé la convention ?
+    <div id="change-current-university-form" <% if (!showForm) { %> hidden <% } %>>
+        <% if (currentConvention.universityId) { %>
+          <h4>Modifier le statut de ma convention</h4>
+        <% } %>
+        <form action="/psychologue/api/renseigner-convention" method="POST">
+        <input type="hidden" name="_csrf" value="<%= _csrf  %>">
+
+        <div class="rf-select-group">
+          <label class="rf-label" for="university">
+            Quelle université vous a contacté pour signer la convention ?
             <span class="red-text">*</span>
-            <span class="rf-hint-text">
-              Renseignez votre situation actuelle pour que nous puissions vous aider à avancer au besoin.
-              Vous pourrez mettre à jour vos réponses plus tard si votre statut change.
-            </span>
-          </legend>
-          <div class="rf-fieldset__content">
-            <div class="rf-radio-group">
-              <input type="radio" id="signed-yes" name="signed" value="yes" required
-                <% if (currentConvention.isConventionSigned) { %> checked <% } %>
+          </label>
+          <select class="rf-select" id="university" name="university" required>
+            <% if (!currentConvention.universityid) { %>
+              <option value="" selected disabled hidden>- Cliquez pour choisir -</option>
+            <% } %>
+            <% universities.forEach(function(university) { %>
+              <option
+                value="<%= university.id %>"
+                <% if (university.id === currentConvention.universityId) { %> selected <% } %>
               >
-              <label class="rf-label" for="signed-yes">Oui</label>
+                <%= university.name %>
+              </option>
+            <% }) %>
+          </select>
+        </div>
+
+        <div class="rf-form-group">
+          <fieldset class="rf-fieldset">
+            <legend class="rf-label rf-mb-1w"> <!-- we don't use rf-fieldset__legend, it looks different -->
+              Avez-vous déjà signé la convention ?
+              <span class="red-text">*</span>
+              <span class="rf-hint-text">
+                Renseignez votre situation actuelle pour que nous puissions vous aider à avancer au besoin.
+                Vous pourrez mettre à jour vos réponses plus tard si votre statut change.
+              </span>
+            </legend>
+            <div class="rf-fieldset__content">
+              <div class="rf-radio-group">
+                <input type="radio" id="signed-yes" name="signed" value="yes" required
+                  <% if (currentConvention.isConventionSigned) { %> checked <% } %>
+                >
+                <label class="rf-label" for="signed-yes">Oui</label>
+              </div>
+              <div class="rf-radio-group">
+                <input type="radio" id="signed-no" name="signed" value="no" required
+                  <% if (!currentConvention.isConventionSigned) { %> checked <% } %>
+                >
+                <label class="rf-label" for="signed-no">Non, pas encore</label>
+              </div>
             </div>
-            <div class="rf-radio-group">
-              <input type="radio" id="signed-no" name="signed" value="no" required
-                <% if (!currentConvention.isConventionSigned) { %> checked <% } %>
-              >
-              <label class="rf-label" for="signed-no">Non, pas encore</label>
-            </div>
-          </div>
-        </fieldset>
-      </div>
-      <div class="rf-my-5w">
-        <button type="submit" class="rf-btn rf-fi-check-line rf-btn--icon-left">Enregistrer</button>
-      </div>
-    </form>
-  </div>
+          </fieldset>
+        </div>
+        <div class="rf-my-5w">
+          <button type="submit" class="rf-btn rf-fi-check-line rf-btn--icon-left">Enregistrer</button>
+        </div>
+      </form>
+    </div>
+  <% } %>
 </div>
 
 <script src="/static/js/selectPayingUniversity.js"></script>


### PR DESCRIPTION
## Problème
La page remboursement ne peut pas s'afficher si il n'y pas de données d'universités.

Ceci a été rencontré sur une review app de staging

## Solution proposée
Pour rendre l'application plus résiliente (accès à la facturation), on affiche la page "remboursement" avec un message d'erreur plutôt que de rediriger vers "mes séances"
