### PR TITLE
refacto: login email with secondary raw connexion link

### DIFF
--- a/controllers/loginController.js
+++ b/controllers/loginController.js
@@ -28,6 +28,7 @@ async function sendLoginEmail(email, loginUrl, token) {
     const html = await ejs.renderFile('./views/emails/login.ejs', {
       loginUrlWithToken: `${loginUrl}?token=${encodeURIComponent(token)}`,
       appName: config.appName,
+      loginUrl: loginUrl,
     });
     await emailUtils.sendMail(email, `Connexion à ${config.appName}`, html);
     console.log(`Login email sent for ${logs.hashForLogs(email)}`);

--- a/views/emails/login.ejs
+++ b/views/emails/login.ejs
@@ -2,7 +2,9 @@
 
 <p>
   Vous avez demandé un lien de connexion à la plateforme <%= appName %>.
-  Pour vous authentifier, vous devez cliquer sur le bouton ci-dessous dans l'heure qui suit la réception de ce message.
+</p>
+<p>
+  Pour vous authentifier, cliquez sur le bouton ci-dessous dans <strong>l'heure qui suit</strong> la réception de ce message - ce bouton n'est utilisable qu'une seule fois.
 </p>
 
 <p>
@@ -11,7 +13,19 @@
   </a>
 </p>
 
-<p>Ou utiliser ce lien :<br /><a href="<%= loginUrlWithToken %>"><%= loginUrlWithToken %></a></p>
+<br/>
+
+<p>
+  Ca n'a pas marché pas en cliquant sur le bouton ?
+ <p>
+   <a title="Redemander un lien de connexion en cas de problème" href="<%= loginUrl %>">Redemander un lien de connexion ici</a> et au lieu de cliquer sur le bouton, essayez de copier ce lien et le coller dans votre navigateur :
+ </p>
+</p>
+<p>
+  <%= loginUrlWithToken %>
+</p>
+
+<br/>
 
 <p>En cas de problème avec votre compte, n'hésitez pas à répondre à ce mail</p>
 


### PR DESCRIPTION
# Motivation
Certains fournisseurs d'emails modifient les liens par mesure de protection et ne permettent pas de se connecter

> https://emea01.safelinks.protection.outlook.com/?NOTRE_LIEN

On propose un lien brute plutôt qu'un lien dans le lien secondaire de connexion

## Avant
![image](https://user-images.githubusercontent.com/4059615/112859052-c21a1600-90b2-11eb-8465-43d8a1c44fec.png)


## Après

![image](https://user-images.githubusercontent.com/4059615/112857873-977b8d80-90b1-11eb-915a-a6c3be50e365.png)
