### PR TITLE
feat: optional INE for patient

### DIFF
--- a/controllers/dashboardController.js
+++ b/controllers/dashboardController.js
@@ -17,7 +17,7 @@ function hasFolderCompleted(patient) {
     notEmptyDoctorAddress = !(!patient.doctorAddress.trim())
   }
 
-  return !!(patient.INE) && patient.hasPrescription && patient.isStudentStatusVerified && notEmptyDoctorName &&
+  return patient.hasPrescription && patient.isStudentStatusVerified && notEmptyDoctorName &&
   notEmptyInstitutionName && notEmptyDoctorAddress;
 }
 

--- a/test/test-dashboardController.js
+++ b/test/test-dashboardController.js
@@ -11,9 +11,9 @@ const format = require('../utils/format')
 
 describe('dashboardController', function() {
   describe('hasFolderCompleted', function() {
-    const hasFolderCompleted = dashboardController.__get__('hasFolderCompleted');
-    it('should return true if patient has all needed info', function() {
-      const patient =  {
+    let patient
+    beforeEach( function() {
+      patient =  {
         firstNames : "firstNames",
         lastName : "lastName",
         INE : "INE",
@@ -22,48 +22,58 @@ describe('dashboardController', function() {
         hasPrescription : true,
         psychologistId : "psychologistId",
         doctorName : "doctorName",
-        doctorAddress : "30000 Nîmes"
+        doctorAddress : "30000 Nîmes",
       }
+    })
 
+    const hasFolderCompleted = dashboardController.__get__('hasFolderCompleted');
+    it('should return true if patient has all needed info', function() {
       hasFolderCompleted(patient).should.equal(true);
     });
 
-    it('should return false if patient does not have all needed info (prescription, student status, doctor name)',
-      function() {
-        let patient =  {
-          firstNames : "firstNames",
-          lastName : "lastName",
-          INE : "INE",
-          institutionName : "institutionName",
-          isStudentStatusVerified : true,
-          hasPrescription : false,
-          psychologistId : "psychologistId",
-          doctorName : "doctorName",
-          doctorAddress : "30000 Nîmes",
-        }
-        hasFolderCompleted(patient).should.equal(false);
-        patient.doctorName=null;
-        patient.hasPrescription=true;
-        hasFolderCompleted(patient).should.equal(false);
-        patient.doctorName='doctorName';
-        patient.isStudentStatusVerified=false;
-        hasFolderCompleted(patient).should.equal(false);
-        patient.isStudentStatusVerified=true;
-        patient.INE='INE';
-        patient.doctorName="    ", // trim should work
-        hasFolderCompleted(patient).should.equal(false);
-        patient.doctorName="doctorName", // trim should work
-        patient.institutionName='    ';
-        hasFolderCompleted(patient).should.equal(false);
-        patient.doctorName="", 
-        patient.institutionName='institutionName';
-        hasFolderCompleted(patient).should.equal(false);
-        patient.doctorName="doctorName",
-        patient.doctorAddress='';
-        hasFolderCompleted(patient).should.equal(false);
-        patient.doctorAddress='    ';
-        hasFolderCompleted(patient).should.equal(false);
-      });
+    it('should return true if INE is missing', function() {
+      patient.INE=null;
+      hasFolderCompleted(patient).should.equal(true);
+    });
+
+    it('should return false if doctor name is missing', function() {
+      patient.doctorName=null;
+      hasFolderCompleted(patient).should.equal(false);
+    });
+
+
+    it('should return false if isStudentStatusVerified is false', function() {
+      patient.isStudentStatusVerified=false;
+      hasFolderCompleted(patient).should.equal(false);
+    });
+
+    it('should return false if hasPrescription is false', function() {
+      patient.hasPrescription=false;
+      hasFolderCompleted(patient).should.equal(false);
+    });
+
+    it('should return false if doctorName is a only white spaces', function() {
+      patient.doctorName="    ", // trim should work
+      hasFolderCompleted(patient).should.equal(false);
+    });
+    it('should return false if doctorName is an empty string', function() {
+      patient.doctorName="";
+      hasFolderCompleted(patient).should.equal(false);
+    });
+
+    it('should return false if institutionName is a only white spaces', function() {
+      patient.institutionName='    ';
+      hasFolderCompleted(patient).should.equal(false);
+    });
+
+    it('should return false if doctorAddress is an empty string', function() {
+      patient.doctorAddress='';
+      hasFolderCompleted(patient).should.equal(false);
+    });
+    it('should return false if doctor adress is a only white spaces', function() {
+      patient.doctorAddress='    ';
+      hasFolderCompleted(patient).should.equal(false);
+    });
   });
   describe('display dashaboard', function() {
     beforeEach(async function(done) {

--- a/test/test-dashboardController.js
+++ b/test/test-dashboardController.js
@@ -28,7 +28,7 @@ describe('dashboardController', function() {
       hasFolderCompleted(patient).should.equal(true);
     });
 
-    it('should return false if patient does not have all needed info (ine, prescription, student status, doctor name)',
+    it('should return false if patient does not have all needed info (prescription, student status, doctor name)',
       function() {
         let patient =  {
           firstNames : "firstNames",
@@ -49,8 +49,6 @@ describe('dashboardController', function() {
         patient.isStudentStatusVerified=false;
         hasFolderCompleted(patient).should.equal(false);
         patient.isStudentStatusVerified=true;
-        patient.INE='';
-        hasFolderCompleted(patient).should.equal(false);
         patient.INE='INE';
         patient.doctorName="    ", // trim should work
         hasFolderCompleted(patient).should.equal(false);

--- a/views/editPatient.ejs
+++ b/views/editPatient.ejs
@@ -59,7 +59,7 @@
         </div>
         <div class="rf-my-3w">
           <!-- todo : JS validation for 11 digit number -->
-          <label class="rf-label" for="ine" aria-describedby="ine-help">Numéro INE de l'étudiant</label>
+          <label class="rf-label" for="ine" aria-describedby="ine-help">Numéro INE de l'étudiant (optionnel)</label>
           <div class="rf-hint-text" id="ine-help">
             Il fait 11 caractères (chiffres et lettres). Il peut être présent sur la carte d'étudiant.
           </div>

--- a/views/myPatients.ejs
+++ b/views/myPatients.ejs
@@ -10,7 +10,7 @@
       <% if (!hasAllPatientsWithCompletedFolders) { %>
         <div class="rf-callout">
           <p class="rf-callout__text">
-           Certains de vos patients n'ont pas leur dossier complet - le numéro INE, l'orientation du medecin, le nom du medecin, sa ville,
+           Certains de vos patients n'ont pas leur dossier complet - vérification du statut d'étudiant, l'orientation du medecin, le nom du medecin, sa ville,
            ou l'université du patient sont manquants.
            <strong>
              Ceci est obligatoire pour facturer les séances du patient.
@@ -26,7 +26,7 @@
                 <%= patient.lastName %> <%= patient.firstNames %>
                 <% if (!patient.hasFolderCompleted) { %>
                   <span class="rf-tag bg-orange-warning  rf-fi-alert-line rf-tag--icon-left rf-tag--sm"
-                  title="Le numéro INE, l'orientation du medecin, le nom du medecin, sa ville, ou l'université du patient sont manquants">
+                  title="Le statut d'étudiant, l'orientation du medecin, le nom du medecin, sa ville, ou l'université du patient sont manquants">
                     Informations manquantes
                   </span>
                 <% } else { %>


### PR DESCRIPTION
# But
Pour simplifier le formulaire des patients, le numéro INE est facultatif, et on s'appuie sur le champs booléen "isStudentStatusVerified" pour dire qu'on a bien affaire à un étudiant

## Résultats
Dans le dashboard les patients qui n'ont pas d'INE ne seront plus considérés comme dossier incomplet

## Tâches à faire qui sont liés dans d'autres PRs:
- [ ] Ajout de la date de naissance pour éviter des problèmes d'homonymes
- [ ] éviter le format strict de 11 caracètres pour l'INE (les anciens INE n'ont pas forcémeent 11 caractères)