### PR TITLE
feat: random order from psy list to balance psy contact from students

### DIFF
--- a/db/psychologists.js
+++ b/db/psychologists.js
@@ -25,7 +25,9 @@ module.exports.getPsychologists = async () => {
         .select()
         .from(module.exports.psychologistsTable)
         .whereNot('archived', true)
-        .where('state', demarchesSimplifiees.DOSSIER_STATE.accepte);
+        .where('state', demarchesSimplifiees.DOSSIER_STATE.accepte)
+        .orderByRaw("RANDOM ()");
+
     return psychologists;
   } catch (err) {
     console.error(`Impossible de récupérer les psychologistes`, err)


### PR DESCRIPTION
## Motivation
Certains psy ont une avalanche de demandes qu'ils n'arrivent pas à absorber.

Il y a certes une demande elevée, mais afin d'aider à équilibrer cette charge parmis les psychologues, nous proposons de changer l'ordre d'apparition alphabétique en aléatoire pour - potentiellement - mieux distribuer la charge sur l'annuaire