### PR TITLE
fix(login): compare email in lowercase

### DIFF
--- a/db/psychologists.js
+++ b/db/psychologists.js
@@ -114,7 +114,7 @@ module.exports.getNumberOfPsychologists = async function getNumberOfPsychologist
 module.exports.getAcceptedPsychologistByEmail = async function getAcceptedPsychologistByEmail(email) {
   return await knex(module.exports.psychologistsTable)
   .where('state', demarchesSimplifiees.DOSSIER_STATE.accepte)
-  .andWhere('personalEmail', email)
+  .andWhere('personalEmail', email.toLowerCase())
   .first()
 }
 

--- a/db/psychologists.js
+++ b/db/psychologists.js
@@ -114,7 +114,9 @@ module.exports.getNumberOfPsychologists = async function getNumberOfPsychologist
 module.exports.getAcceptedPsychologistByEmail = async function getAcceptedPsychologistByEmail(email) {
   return await knex(module.exports.psychologistsTable)
   .where('state', demarchesSimplifiees.DOSSIER_STATE.accepte)
-  .andWhere('personalEmail', email.toLowerCase())
+  .andWhere(
+    knex.raw('LOWER("personalEmail") = ?', email.toLowerCase())
+  )
   .first()
 }
 

--- a/test/test-dbPsychologists.js
+++ b/test/test-dbPsychologists.js
@@ -114,6 +114,13 @@ describe('DB Psychologists', () => {
       psy.personalEmail.should.be.equal(psyList[0].personalEmail);
     });
 
+    it("should return a psy if we enter a known login email capitalized", async () => {
+      await dbPsychologists.savePsychologistInPG(psyList);
+      const psy = await dbPsychologists.getAcceptedPsychologistByEmail(psyList[0].personalEmail.toUpperCase());
+      psy.email.should.be.equal(psyList[0].email);
+      psy.personalEmail.should.be.equal(psyList[0].personalEmail);
+    });
+
     it("should return undefined if we enter a unknown email", async () => {
       const unknownPsy = await dbPsychologists.getAcceptedPsychologistByEmail("unknown@unknown.org")
 


### PR DESCRIPTION
## Motivation
Certains utilisateurs utilisent un email avec des majuscules pour se logguer, tous les emails étaient en lowercase en base, cela cause un mauvais match, les empechant de se connecter.

Cette PR compare les emails en lower case pour se logguer, mais utilise la même case pour envoyer l'email