### PR TITLE
refacto(selectingPayingUni): use assignedUni instead of declaredUni i…

### DIFF
--- a/db/psychologists.js
+++ b/db/psychologists.js
@@ -203,7 +203,7 @@ module.exports.getConventionInfo = async (psychologistId) => {
     .select(`${universitiesTable}.name as universityName`,
       `${universitiesTable}.id as universityId`,
       `${psyTable}.isConventionSigned`)
-    .innerJoin(universitiesTable, `${psyTable}.declaredUniversityId`, `${universitiesTable}.id`)
+    .innerJoin(universitiesTable, `${psyTable}.assignedUniversityId`, `${universitiesTable}.id`)
     .where(`${psyTable}.dossierNumber`, psychologistId)
   return psyArray[0]
 }

--- a/test/helper/clean.js
+++ b/test/helper/clean.js
@@ -41,7 +41,7 @@ module.exports.getOnePsy = function getOnePsy(personalEmail = 'loginemail@beta.g
     training: "[\"Connaissance et pratique des outils diagnostic psychologique\",\"Connaissance des troubles psychopathologiques du jeune adulte : dépressions\",\"risques suicidaires\",\"addictions\",\"comportements à risque\",\"troubles alimentaires\",\"décompensation schizophrénique\",\"psychoses émergeantes ainsi qu’une pratique de leur repérage\",\"Connaissance et pratique des dispositifs d’accompagnement psychologique et d’orientation (CMP...)\"]",
     departement: `${module.exports.getRandomInt()} - Calvados`,
     university: `${module.exports.getRandomInt()} Université`,
-    declaredUniversityId: uniId,
+    declaredUniversityId: null, // not useful after script/matchPsychologistsToUniversities.js was used
     assignedUniversityId: uniId,
     region: "Normandie",
     languages: "Français ,Anglais, et Espagnol"

--- a/test/helper/clean.js
+++ b/test/helper/clean.js
@@ -42,6 +42,7 @@ module.exports.getOnePsy = function getOnePsy(personalEmail = 'loginemail@beta.g
     departement: `${module.exports.getRandomInt()} - Calvados`,
     university: `${module.exports.getRandomInt()} Université`,
     declaredUniversityId: uniId,
+    assignedUniversityId: uniId,
     region: "Normandie",
     languages: "Français ,Anglais, et Espagnol"
   };

--- a/test/test-dbPsychologists.js
+++ b/test/test-dbPsychologists.js
@@ -233,8 +233,7 @@ describe('DB Psychologists', () => {
       await dbPsychologists.savePsychologistInPG([psy]);
       const savedPsy = await dbPsychologists.getAcceptedPsychologistByEmail(psy.personalEmail);
       // Check that fields are not set pre-test
-      expect(savedPsy.assignedUniversityId).not.to.exist
-      expect(savedPsy.declaredUniversityId).to.not.equal(univUUID)
+      expect(savedPsy.assignedUniversityId).to.not.equal(univUUID)
 
       await dbPsychologists.saveAssignedUniversity(
         savedPsy.dossierNumber,


### PR DESCRIPTION
Suite à #159 #149 on peut maintenant utiliser le champs "assignedUniversity" plutôt que "declaredUniversity" dans la page "Mes remboursement"

Ceci permettra d'informer les universités de manière automatique par #148 