### PR TITLE
fix/do not count deleted appointments

### DIFF
--- a/db/appointments.js
+++ b/db/appointments.js
@@ -39,6 +39,7 @@ module.exports.getCountAppointmentsByYearMonth = async (psychologistId) => {
         , EXTRACT(YEAR from "appointmentDate") AS year
         , EXTRACT(MONTH from "appointmentDate") AS month`))
       .where("psychologistId", psychologistId)
+      .whereNot(`${appointmentsTable}.deleted`, true)
       .groupByRaw(`"psychologistId"
         , EXTRACT(YEAR from "appointmentDate")
         , EXTRACT(MONTH from "appointmentDate")`)

--- a/db/appointments.js
+++ b/db/appointments.js
@@ -79,6 +79,7 @@ module.exports.getMonthlyAppointmentsSummary = async (year, month) => {
         `))
         .whereRaw(`EXTRACT(YEAR from ${appointmentsTable}."appointmentDate") = ${year}`)
         .andWhereRaw(`EXTRACT(MONTH from ${appointmentsTable}."appointmentDate") = ${month}`)
+        .whereNot(`${appointmentsTable}.deleted`, true)
         .innerJoin(`${dbPsychologists.psychologistsTable}`,
           `${appointmentsTable}.psychologistId`,
           `${dbPsychologists.psychologistsTable}.dossierNumber`)

--- a/test/test-dbAppointments.js
+++ b/test/test-dbAppointments.js
@@ -92,6 +92,10 @@ describe('DB Appointments', () => {
       await dbAppointments.insertAppointment(new Date('2021-06-03'), patient.id, psy.dossierNumber)
       await dbAppointments.insertAppointment(new Date('2021-07-03'), patient.id, psy.dossierNumber)
 
+      // For april (should be output - as deleted)
+      const toDelete = await dbAppointments.insertAppointment(new Date('2021-04-01'), patient.id, psy.dossierNumber)
+      await dbAppointments.deleteAppointment(toDelete.id, psy.dossierNumber)
+
       const output = await dbAppointments.getCountAppointmentsByYearMonth(psy.dossierNumber);
 
       assert(output.length === 4); // 4 months

--- a/test/test-dbAppointments.js
+++ b/test/test-dbAppointments.js
@@ -155,6 +155,10 @@ describe('DB Appointments', () => {
       await dbAppointments.insertAppointment(new Date('2021-03-01'), patient.id, psy.dossierNumber)
       await dbAppointments.insertAppointment(new Date('2021-03-02'), patient2.id, psy2.dossierNumber)
 
+      // For april (should be output - as deleted)
+      const toDelete = await dbAppointments.insertAppointment(new Date('2021-04-01'), patient.id, psy.dossierNumber)
+      await dbAppointments.deleteAppointment(toDelete.id, psy.dossierNumber)
+
       const output = await dbAppointments.getMonthlyAppointmentsSummary(year, month);
 
       assert.equal(output.length, 2); // 2 psys for april


### PR DESCRIPTION
Dans le total des psychologues et ou des universités, ne pas prendre en compte les séances avec le statut supprimé