### PR TITLE
fix(cron email): every first of the month

### DIFF
--- a/cron_jobs/cron.js
+++ b/cron_jobs/cron.js
@@ -7,7 +7,7 @@ const sentry = require('../utils/sentry');
 sentry.initCaptureConsole();
 
 const jobs = [{
-  cronTime: '0 8 1-7 * 1', // first monday of the month : https://crontab.guru/#0_8_1-7_*_1
+  cronTime: '0 8 1 * *', // first of the month : https://crontab.guru/#0_8_1_*_*
   onTick: cronUniversityPayments.SendSummaryToUniversities,
   start: true,
   timeZone: 'Europe/Paris',


### PR DESCRIPTION
ce cron ne fonctionne pas : https://crontab.guru/#0_8_1-7_*_1 cette PR propose d'utiliser un plus simple pour lancer le job de récapitulatif d'email seulement les 1er jour de chaque mois

https://crontab.guru/#0_8_1_*_*