### PR TITLE
Feat/remove-patient

### DIFF
--- a/controllers/patientsController.js
+++ b/controllers/patientsController.js
@@ -230,3 +230,28 @@ module.exports.createNewPatient = async (req, res) => {
     return res.redirect('/psychologue/nouveau-patient');
   }
 };
+
+module.exports.deletePatientValidators = [
+  check('patientId')
+    .isUUID()
+    .withMessage('Vous devez spécifier un patient à supprimer.'),
+];
+
+module.exports.deletePatient = async (req, res) => {
+  if (!validation.checkErrors(req)) {
+    return res.redirect('/psychologue/mes-seances');
+  }
+
+  const { patientId } = req.body;
+  try {
+    const psychologistId = cookie.getCurrentPsyId(req);
+    await dbPatients.deletePatient(patientId, psychologistId);
+    console.log(`Patient deleted ${patientId} by psy id ${psychologistId}`);
+    req.flash('info', 'Le patient a bien été supprimé.');
+  } catch (err) {
+    req.flash('error', 'Erreur. Le patient n\'est pas supprimé. Pourriez-vous réessayer ?');
+    console.error('Erreur pour supprimer le patient', err);
+  }
+
+  return res.redirect('/psychologue/mes-seances');
+};

--- a/db/patients.js
+++ b/db/patients.js
@@ -89,3 +89,22 @@ module.exports.updatePatient = async (
     throw new Error('Erreur de modification du patient');
   }
 };
+
+module.exports.deletePatient = async (id, psychologistId) => {
+  try {
+    const deletedPatient = await knex(module.exports.patientsTable)
+      .where('id', id)
+      .where('psychologistId', psychologistId)
+      .update({
+        deleted: true,
+        updatedAt: date.getDateNowPG(),
+      });
+
+    console.log(`Patient id ${id} deleted by psy id ${psychologistId}`);
+
+    return deletedPatient;
+  } catch (err) {
+    console.error('Erreur de suppression du patient', err);
+    throw new Error('Erreur de suppression du patient');
+  }
+};

--- a/db/patients.js
+++ b/db/patients.js
@@ -23,6 +23,7 @@ module.exports.getPatients = async (psychologistId) => {
   try {
     const patientArray = await knex(module.exports.patientsTable)
         .where('psychologistId', psychologistId)
+        .where('deleted', false)
         .orderBy('lastName');
     return patientArray;
   } catch (err) {

--- a/index.js
+++ b/index.js
@@ -203,6 +203,9 @@ if (config.featurePsyPages) {
   app.post('/psychologue/api/modifier-patient',
     patientsController.editPatientValidators,
     patientsController.editPatient);
+  app.post('/psychologue/api/supprimer-patient',
+    patientsController.deletePatientValidators,
+    patientsController.deletePatient);
 
   if (config.featureReimbursementPage) {
     app.get('/psychologue/mes-remboursements', reimbursementController.reimbursement);

--- a/test/test-date.js
+++ b/test/test-date.js
@@ -30,7 +30,7 @@ describe('date', () => {
 
     it('should return null if Date is null', async () => {
       const output = date.toFormatDDMMYYYY(null);
-      assert(output === null);
+      assert.isNull(output);
     });
   });
 

--- a/test/test-dbAppointments.js
+++ b/test/test-dbAppointments.js
@@ -43,15 +43,15 @@ describe('DB Appointments', () => {
       .where('psychologistId', psy.dossierNumber)
       .where('patientId', patient.id);
 
-      assert(appointmentsBeforeDelete[0].updatedAt === null);
-      assert(appointmentsBeforeDelete[0].deleted === false);
+      assert.isNull(appointmentsBeforeDelete[0].updatedAt);
+      assert.isFalse(appointmentsBeforeDelete[0].deleted);
       await dbAppointments.deleteAppointment(appointmentsBeforeDelete[0].id, psy.dossierNumber);
 
       const appointmentsAfterDelete = await knex.from(dbAppointments.appointmentsTable)
       .where('psychologistId', psy.dossierNumber)
       .where('patientId', patient.id);
-      assert(appointmentsAfterDelete[0].deleted === true);
-      assert(appointmentsAfterDelete[0].updatedAt !== null);
+      assert.isTrue(appointmentsAfterDelete[0].deleted);
+      assert.isNotNull(appointmentsAfterDelete[0].updatedAt);
     });
   });
 
@@ -98,19 +98,19 @@ describe('DB Appointments', () => {
 
       const output = await dbAppointments.getCountAppointmentsByYearMonth(psy.dossierNumber);
 
-      assert(output.length === 4); // 4 months
-      assert(output[0].countAppointments === 4);
-      assert(output[0].year === 2021);
-      assert(output[0].month === 3);
-      assert(output[1].countAppointments === 1);
-      assert(output[1].year === 2021);
-      assert(output[1].month === 4);
-      assert(output[2].countAppointments === 1);
-      assert(output[2].year === 2021);
-      assert(output[2].month === 6);
-      assert(output[3].countAppointments === 1);
-      assert(output[3].year === 2021);
-      assert(output[3].month === 7);
+      assert.strictEqual(output.length, 4); // 4 months
+      assert.strictEqual(output[0].countAppointments, 4);
+      assert.strictEqual(output[0].year, 2021);
+      assert.strictEqual(output[0].month, 3);
+      assert.strictEqual(output[1].countAppointments, 1);
+      assert.strictEqual(output[1].year, 2021);
+      assert.strictEqual(output[1].month, 4);
+      assert.strictEqual(output[2].countAppointments, 1);
+      assert.strictEqual(output[2].year, 2021);
+      assert.strictEqual(output[2].month, 6);
+      assert.strictEqual(output[3].countAppointments, 1);
+      assert.strictEqual(output[3].year, 2021);
+      assert.strictEqual(output[3].month, 7);
     });
   });
 
@@ -271,9 +271,9 @@ describe('DB Appointments', () => {
 
       const output = await dbAppointments.getAppointments(psy.dossierNumber);
 
-      assert(output.length === 2);
-      assert(output[0].deleted === false);
-      assert(output[1].deleted === false);
+      assert.strictEqual(output.length, 2);
+      assert.isFalse(output[0].deleted);
+      assert.isFalse(output[1].deleted);
     });
 
     it('should only return psy id appointments', async () => {

--- a/test/test-dbDsApiCursor.js
+++ b/test/test-dbDsApiCursor.js
@@ -13,13 +13,13 @@ describe('DB Ds Api Cursor', () => {
     it('should return undefined if there is no cursor saved', async () => {
       const output = await dbDsApiCursor.getLatestCursorSaved();
 
-      assert(output === undefined);
+      assert.isUndefined(output);
     });
 
     it('should return undefined if we do not want to use the cursor', async () => {
       const output = await dbDsApiCursor.getLatestCursorSaved(false);
 
-      assert(output === undefined);
+      assert.isUndefined(output);
     });
 
     it('should return the latest cursor saved', async () => {
@@ -28,7 +28,7 @@ describe('DB Ds Api Cursor', () => {
 
       const output = await dbDsApiCursor.getLatestCursorSaved();
 
-      assert(output === myCursor);
+      assert.strictEqual(output, myCursor);
     });
   });
 });

--- a/test/test-dbLoginToken.js
+++ b/test/test-dbLoginToken.js
@@ -31,7 +31,7 @@ describe('DB Login token', () => {
       await dbToginToken.insert(token, email, expiredDate);
       const result = await dbToginToken.getByToken(token);
 
-      assert(result === undefined);
+      assert.isUndefined(result);
     });
   });
 
@@ -56,7 +56,7 @@ describe('DB Login token', () => {
 
       await dbToginToken.delete(token);
       const result = await dbToginToken.getByToken(token);
-      assert(result === undefined);
+      assert.isUndefined(result);
     });
 
     it('should throw error when token does not exist', async () => {

--- a/test/test-dbPatients.js
+++ b/test/test-dbPatients.js
@@ -141,4 +141,32 @@ describe('DB Patients', () => {
       expect(newPatient.lastName).equal(newLastName);
     });
   });
+
+  describe('deletePatientInPG', () => {
+    it('should change deleted boolean to true and update updatedAt field', async () => {
+      const psychologistId = '357a2085-6d32-44db-8fe6-979c7339fd47';
+      const patient = await dbPatients.insertPatient(
+        firstNames,
+        lastName,
+        studentNumber,
+        institutionName,
+        isStudentStatusVerified,
+        hasPrescription,
+        psychologistId,
+        doctorName,
+        doctorAddress,
+        dateOfBirth,
+      );
+
+      const patientBeforeDelete = await dbPatients.getPatientById(patient.id, psychologistId);
+
+      assert(patientBeforeDelete.updatedAt === null);
+      assert(patientBeforeDelete.deleted === false);
+      await dbPatients.deletePatient(patientBeforeDelete.id, psychologistId);
+
+      const patientAfterDelete = await dbPatients.getPatientById(patient.id, psychologistId);
+      assert(patientAfterDelete.deleted === true);
+      assert(patientAfterDelete.updatedAt !== null);
+    });
+  });
 });

--- a/test/test-dbPatients.js
+++ b/test/test-dbPatients.js
@@ -178,13 +178,13 @@ describe('DB Patients', () => {
 
       const patientBeforeDelete = await dbPatients.getPatientById(patient.id, psychologistId);
 
-      assert(patientBeforeDelete.updatedAt === null);
-      assert(patientBeforeDelete.deleted === false);
+      assert.isNull(patientBeforeDelete.updatedAt);
+      assert.isFalse(patientBeforeDelete.deleted);
       await dbPatients.deletePatient(patientBeforeDelete.id, psychologistId);
 
       const patientAfterDelete = await dbPatients.getPatientById(patient.id, psychologistId);
-      assert(patientAfterDelete.deleted === true);
-      assert(patientAfterDelete.updatedAt !== null);
+      assert.isTrue(patientAfterDelete.deleted);
+      assert.isNotNull(patientAfterDelete.updatedAt);
     });
   });
 

--- a/test/test-dbPatients.js
+++ b/test/test-dbPatients.js
@@ -102,6 +102,24 @@ describe('DB Patients', () => {
         expect(error).to.be.an('Error');
       }
     });
+
+    it('should set deleted to false by default in PG', async () => {
+      const psychologistId = '357a2085-6d32-44db-8fe6-979c7339fd47';
+      const insertedPatient = await dbPatients.insertPatient(
+        firstNames,
+        lastName,
+        studentNumber,
+        institutionName,
+        isStudentStatusVerified,
+        hasPrescription,
+        psychologistId,
+        doctorName,
+        doctorAddress,
+        dateOfBirth,
+      );
+
+      expect(insertedPatient.deleted).equal(false);
+    });
   });
 
   describe('updatePatientInPG', () => {
@@ -167,6 +185,47 @@ describe('DB Patients', () => {
       const patientAfterDelete = await dbPatients.getPatientById(patient.id, psychologistId);
       assert(patientAfterDelete.deleted === true);
       assert(patientAfterDelete.updatedAt !== null);
+    });
+  });
+
+  describe('getPatientsInDB', () => {
+    it('should return patients', async () => {
+      const psychologistId = '357a2085-6d32-44db-8fe6-979c7339fd47';
+      await dbPatients.insertPatient(
+        firstNames,
+        lastName,
+        studentNumber,
+        institutionName,
+        isStudentStatusVerified,
+        hasPrescription,
+        psychologistId,
+        doctorName,
+        doctorAddress,
+        dateOfBirth,
+      );
+
+      const patients = await dbPatients.getPatients(psychologistId);
+      expect(patients).to.have.length(1);
+    });
+
+    it('should not return deleted patients', async () => {
+      const psychologistId = '357a2085-6d32-44db-8fe6-979c7339fd47';
+      const patient = await dbPatients.insertPatient(
+        firstNames,
+        lastName,
+        studentNumber,
+        institutionName,
+        isStudentStatusVerified,
+        hasPrescription,
+        psychologistId,
+        doctorName,
+        doctorAddress,
+        dateOfBirth,
+      );
+      await dbPatients.deletePatient(patient.id, psychologistId);
+      
+      const patients = await dbPatients.getPatients(psychologistId);
+      expect(patients).to.have.length(0);
     });
   });
 });

--- a/test/test-dbPatients.js
+++ b/test/test-dbPatients.js
@@ -223,7 +223,7 @@ describe('DB Patients', () => {
         dateOfBirth,
       );
       await dbPatients.deletePatient(patient.id, psychologistId);
-      
+
       const patients = await dbPatients.getPatients(psychologistId);
       expect(patients).to.have.length(0);
     });

--- a/test/test-dbPsychologists.js
+++ b/test/test-dbPsychologists.js
@@ -50,7 +50,7 @@ describe('DB Psychologists', () => {
   describe('getNumberOfPsychologists', () => {
     it('should return the number of elements in the psychologists table', async () => {
       const shouldBeZero = await dbPsychologists.getNumberOfPsychologists();
-      assert(shouldBeZero.length === 0);
+      shouldBeZero.should.have.length(0);
 
       await dbPsychologists.savePsychologistInPG(psyList);
       const shouldBeOne = await dbPsychologists.getNumberOfPsychologists();
@@ -103,7 +103,7 @@ describe('DB Psychologists', () => {
       const shouldBeOne = await dbPsychologists.getPsychologists();
       shouldBeOne.length.should.be.equal(1);
       shouldBeOne[0].lastName.should.be.equal(psyList[0].lastName.toUpperCase());
-      assert(shouldBeOne[0].loginEmail === undefined);
+      assert.isUndefined(shouldBeOne[0].loginEmail);
     });
   });
 
@@ -125,39 +125,39 @@ describe('DB Psychologists', () => {
     it('should return undefined if we enter a unknown email', async () => {
       const unknownPsy = await dbPsychologists.getAcceptedPsychologistByEmail('unknown@unknown.org');
 
-      assert(undefined === unknownPsy);
+      assert.isUndefined(unknownPsy);
     });
 
     it("should return undefined if we dont use 'personalEmail' but 'email' as the login", async () => {
       await dbPsychologists.savePsychologistInPG(psyList);
       const unknownPsy = await dbPsychologists.getAcceptedPsychologistByEmail(psyList[0].email);
-      assert(undefined === unknownPsy);
+      assert.isUndefined(unknownPsy);
     });
 
     it('should return undefined if known email but not accepte state', async () => {
       psyList[0].state = demarchesSimplifiees.DOSSIER_STATE.sans_suite;
       await dbPsychologists.savePsychologistInPG(psyList);
       const unknownPsy = await dbPsychologists.getAcceptedPsychologistByEmail(psyList[0].personalEmail);
-      assert(undefined === unknownPsy);
+      assert.isUndefined(unknownPsy);
     });
     it('should return undefined if known email but en_construction state', async () => {
       psyList[0].state = demarchesSimplifiees.DOSSIER_STATE.en_construction;
       await dbPsychologists.savePsychologistInPG(psyList);
       const unknownPsy = await dbPsychologists.getAcceptedPsychologistByEmail(psyList[0].personalEmail);
-      assert(undefined === unknownPsy);
+      assert.isUndefined(unknownPsy);
     });
     it('should return undefined if known email but en_instruction state', async () => {
       psyList[0].state = demarchesSimplifiees.DOSSIER_STATE.en_instruction;
       await dbPsychologists.savePsychologistInPG(psyList);
       const unknownPsy = await dbPsychologists.getAcceptedPsychologistByEmail(psyList[0].personalEmail);
-      assert(undefined === unknownPsy);
+      assert.isUndefined(unknownPsy);
     });
 
     it('should return undefined if known email but refusé state', async () => {
       psyList[0].state = demarchesSimplifiees.DOSSIER_STATE.refuse;
       await dbPsychologists.savePsychologistInPG(psyList);
       const unknownPsy = await dbPsychologists.getAcceptedPsychologistByEmail(psyList[0].personalEmail);
-      assert(undefined === unknownPsy);
+      assert.isUndefined(unknownPsy);
     });
   });
 
@@ -182,7 +182,7 @@ describe('DB Psychologists', () => {
       psyList[0].state = demarchesSimplifiees.DOSSIER_STATE.accepte;
       await dbPsychologists.savePsychologistInPG(psyList);
       const psy = await dbPsychologists.getNotYetAcceptedPsychologistByEmail(psyList[0].personalEmail);
-      assert(undefined === psy);
+      assert.isUndefined(psy);
     });
   });
 

--- a/test/test-demarchesSimplifiees.js
+++ b/test/test-demarchesSimplifiees.js
@@ -102,7 +102,7 @@ describe('Demarches Simplifiess', () => {
 
       const getNextCursor = demarchesSimplifiees.__get__('getNextCursor');
 
-      assert(getNextCursor(apiResponse) === undefined);
+      assert.isUndefined(getNextCursor(apiResponse));
     });
   });
 
@@ -173,7 +173,7 @@ describe('Demarches Simplifiess', () => {
 
       const getNextCursor = demarchesSimplifiees.__get__('getNextCursor');
 
-      assert(getNextCursor(apiResponse) === undefined);
+      assert.isUndefined(getNextCursor(apiResponse));
     });
   });
 

--- a/test/test-patientsController.js
+++ b/test/test-patientsController.js
@@ -844,7 +844,7 @@ describe('patientsController', () => {
     });
   });
 
-  describe.only('delete patient', () => {
+  describe('delete patient', () => {
     beforeEach(async () => {
       await clean.cleanAllPatients();
       return Promise.resolve();

--- a/test/test-patientsController.js
+++ b/test/test-patientsController.js
@@ -28,7 +28,7 @@ const makePatient = async (psychologistId) => {
   );
   // Check patient is inserted
   const createdPatient = await dbPatients.getPatientById(patient.id, psychologistId);
-  chai.assert(!!createdPatient);
+  chai.assert.exists(createdPatient);
   return patient;
 };
 


### PR DESCRIPTION
Cette PR n'ajoute que la partie back de la suppression d'un patient. Ajouter la fonctionnalité côté front n'offrait pas un rendu agréable en l'état. Elle sera donc ajoutée après séparation des séances et des patients dans 2 pages différentes.

Il s'agit d'un changement de valeur du booléen "deleted". La seule implication est qu'il n'est plus affiché dans la liste des patients.
Tous les autres usages sont restés inchangés.

Pour ajouter le bouton côté front : 
```
<form action="/psychologue/api/supprimer-patient" method="POST">
	<input type="hidden" name="_csrf" value="<%= _csrf  %>">
	<input hidden name="patientId" value="<%= patient.id %>" />
	<button type="submit" class="fr-btn fr-btn--secondary fr-btn--sm fr-fi-close-line fr-btn--icon-left">
	  Supprimer
	</button>
</form>
```