### PR TITLE
fix(cron): do not update assignedUniversityId for a already existing psy

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Santé Psy Étudiants listening at http://localhost:8080
 Pour afficher une liste de psychologues, nous importons les données venant de l'API démarches simplifiées (DS) dans la base de données Postgresql à l'aide d'un cron. Cela nous permet un meilleur taux de réponses et une maitrise en cas de pic de traffic.
 
 
-L'API DS est appellée à intervalle regulier à l'aide d'un CRON pour mettre à jour la table PG `psychologists` et on stockera le dernier `cursor` qui correspond à la dernière page requête de l'API dans la table PG `ds_api_cursor` pour ne rappeller que les pages necessaires et limiter le nombre d'appel à l'API DS, ceci est fait à l'aide d'un cron.
+L'API DS est appellée à intervalle regulier à l'aide d'un CRON pour mettre à jour la table PG `psychologists` et on stockera le dernier `cursor` qui correspond à la dernière page requête de l'API dans la table PG `ds_api_cursor` pour ne rappeller que les pages necessaires et limiter le nombre d'appel à l'API DS.
 
 Cependant, certaines données dans DS vont être modifiées au fil du temps, et il nous est donc obligatoire de mettre à jour toutes les données, dans ce cas là nous n'utilisons pas le `cursor` de l'API à l'aide d'un 2ème CRON moins fréquent.
 

--- a/db/psychologists.js
+++ b/db/psychologists.js
@@ -126,7 +126,7 @@ module.exports.savePsychologistInPG = async function savePsychologistInPG(psyLis
         adeli: psy.adeli,
         diploma: psy.diploma,
         languages: addFrenchLanguageIfMissing(psy.languages),
-        assignedUniversityId,
+        // assignedUniversityId, do not update assignedId on already existing psy
         updatedAt,
       });
     } catch (err) {

--- a/db/psychologists.js
+++ b/db/psychologists.js
@@ -102,7 +102,7 @@ module.exports.savePsychologistInPG = async function savePsychologistInPG(psyLis
 
     psy.languages = addFrenchLanguageIfMissing(psy.languages);
 
-    const assignedUniversityId = dbUniversities.getAssignedUniversityId(psy, universities);
+    psy.assignedUniversityId = dbUniversities.getAssignedUniversityId(psy, universities);
 
     try {
       return knex(module.exports.psychologistsTable)

--- a/test/test-dbUniversities.js
+++ b/test/test-dbUniversities.js
@@ -21,7 +21,7 @@ describe('DB Universities', () => {
     });
 
     it('should get the same assigned university if already assigned', async () => {
-      const alreadyAssignedUniId = 'aa4d80e0-c2c4-50c5-94d7-a595c34ec81e';
+      const alreadyAssignedUniId = 'alreadyAssignedUniId';
       const psy = {
         departement: '30 - Gard',
         dossierNumber: 'dd4d80e0-c2c4-50c5-94d7-a595c34ec81e',


### PR DESCRIPTION
L'API DS ne nous retourne pas l'assignation de l'université pour un psy, car elle est seulement stockée dans PG. Ca veut dire que le CRON mettait tout le temps à jour l'assignedUniversityId - car pour lui la valeur n'existait pas.

Ce fix permet de seulement mettre assignedUniversityId pour les nouveaux cas (insert) - ceux qui sont déjà connus dans PG ne seront pas mis à jour (onConflict / merge)

