### PR TITLE
fix: change assigned uni id instead of declared uni id

### DIFF
--- a/db/psychologists.js
+++ b/db/psychologists.js
@@ -184,13 +184,13 @@ module.exports.countAcceptedPsychologistsByPersonalEmail = () => knex(module.exp
     .count('*')
     .groupBy('personalEmail', 'state');
 
-module.exports.updateConventionInfo = async (psychologistId, declaredUniversityId, isConventionSigned) => {
+module.exports.updateConventionInfo = async (psychologistId, assignedUniversityId, isConventionSigned) => {
   const updated = await knex(module.exports.psychologistsTable)
     .where({
       dossierNumber: psychologistId,
     })
     .update({
-      declaredUniversityId,
+      assignedUniversityId,
       isConventionSigned,
       updatedAt: date.getDateNowPG(),
     });

--- a/test/test-dbPsychologists.js
+++ b/test/test-dbPsychologists.js
@@ -195,7 +195,7 @@ describe('DB Psychologists', () => {
       const savedPsy = await dbPsychologists.getAcceptedPsychologistByEmail(psy.personalEmail);
       // Check that fields are not set pre-test
       expect(savedPsy.isConventionSigned).not.to.exist;
-      expect(savedPsy.declaredUniversityId).to.not.equal(univUUID);
+      expect(savedPsy.assignedUniversityId).to.not.equal(univUUID);
 
       await dbPsychologists.updateConventionInfo(
         savedPsy.dossierNumber,
@@ -206,7 +206,7 @@ describe('DB Psychologists', () => {
       const updatedPsy = await dbPsychologists.getAcceptedPsychologistByEmail(psy.personalEmail);
 
       expect(updatedPsy.isConventionSigned).to.equal(true);
-      expect(updatedPsy.declaredUniversityId).to.equal(univUUID);
+      expect(updatedPsy.assignedUniversityId).to.equal(univUUID);
     });
 
     it('should not update conventionInfo if psychologistId is unknown', async () => {

--- a/test/test-reimbursementController.js
+++ b/test/test-reimbursementController.js
@@ -87,7 +87,7 @@ describe('reimbursementController', () => {
         .then(async () => {
           const updatedPsy = await dbPsychologists.getAcceptedPsychologistByEmail(psyEmail);
           chai.expect(updatedPsy.isConventionSigned).to.equal(true);
-          chai.expect(updatedPsy.declaredUniversityId).to.equal(university.id);
+          chai.expect(updatedPsy.assignedUniversityId).to.equal(university.id);
         });
     });
 


### PR DESCRIPTION
Bug sur le formulaire "remboursement de mes séances"

Lorsqu'on change d'université de rattachement, cela modifie l'ancien champs "declared uni id" au lieu de "d'assigned uni id"