### PR TITLE
feat(emailUni): add dashboark link inside universities summary email

### DIFF
--- a/views/emails/summaryUniversity.ejs
+++ b/views/emails/summaryUniversity.ejs
@@ -19,7 +19,14 @@
   <% }); %> 
 </ul>
 
+
+<p>Vous pouvez également, si vous avez reçu un compte et défini votre mot de passe, accéder à ces données sur
+  <a href="https://stats.santepsyetudiant.beta.gouv.fr/">le tableau de bord de votre université.</a>
+</p>
+
+
 <br/>
+
 
 <p>Si vous avez des doutes ou d'autres interrogations, n'hésitez pas à nous écrire en répondant à ce mail.</p>
 


### PR DESCRIPTION
Ajout de stats.santepsyetudiant.beta.gouv.fr/ dans l'email de récapitulatif de séances qui part tous les 1er de mois dans le cron [SendSummaryToUniversities,](https://github.com/betagouv/sante-psy/blob/main/cron_jobs/cron.js#L16-L21)

## Aperçu de l'email
![image](https://user-images.githubusercontent.com/4059615/119983683-c2eefb80-bfc0-11eb-983a-c35f51d35cac.png)
