### PR TITLE
Fix tableau récapitulatif si séance créée le premier jour du mois

### DIFF
--- a/db/appointments.js
+++ b/db/appointments.js
@@ -36,13 +36,13 @@ module.exports.getCountAppointmentsByYearMonth = async (psychologistId) => {
     const query = await knex(appointmentsTable)
       .select(knex.raw(`CAST(COUNT(*) AS INTEGER) AS "countAppointments"
         , "psychologistId"
-        , EXTRACT(YEAR from "appointmentDate") AS year
-        , EXTRACT(MONTH from "appointmentDate") AS month`))
+        , EXTRACT(YEAR from "appointmentDate" AT TIME ZONE 'Europe/Paris') AS year
+        , EXTRACT(MONTH from "appointmentDate" AT TIME ZONE 'Europe/Paris') AS month`))
       .where('psychologistId', psychologistId)
       .whereNot(`${appointmentsTable}.deleted`, true)
       .groupByRaw(`"psychologistId"
-        , EXTRACT(YEAR from "appointmentDate")
-        , EXTRACT(MONTH from "appointmentDate")`)
+        , EXTRACT(YEAR from "appointmentDate" AT TIME ZONE 'Europe/Paris')
+        , EXTRACT(MONTH from "appointmentDate" AT TIME ZONE 'Europe/Paris')`)
       .orderBy([{ column: 'year', order: 'asc' }, { column: 'month', order: 'asc' }]);
 
     return query;
@@ -78,8 +78,9 @@ module.exports.getMonthlyAppointmentsSummary = async (year, month) => {
         , ${dbPsychologists.psychologistsTable}."lastName"
         , ${dbPsychologists.psychologistsTable}."personalEmail"
         `))
-        .whereRaw(`EXTRACT(YEAR from ${appointmentsTable}."appointmentDate") = ${year}`)
-        .andWhereRaw(`EXTRACT(MONTH from ${appointmentsTable}."appointmentDate") = ${month}`)
+        .whereRaw(`EXTRACT(YEAR from ${appointmentsTable}."appointmentDate" AT TIME ZONE 'Europe/Paris') = ${year}`)
+        // eslint-disable-next-line max-len
+        .andWhereRaw(`EXTRACT(MONTH from ${appointmentsTable}."appointmentDate" AT TIME ZONE 'Europe/Paris') = ${month}`)
         .whereNot(`${appointmentsTable}.deleted`, true)
         .innerJoin(`${dbPsychologists.psychologistsTable}`,
           `${appointmentsTable}.psychologistId`,
@@ -110,12 +111,12 @@ module.exports.getCountPatientsByYearMonth = async (psychologistId) => {
   try {
     const query = await knex(appointmentsTable)
       .select(knex.raw(`CAST(COUNT(DISTINCT "patientId") AS INTEGER) AS "countPatients"
-        , EXTRACT(YEAR from "appointmentDate") AS year
-        , EXTRACT(MONTH from "appointmentDate") AS month`))
+        , EXTRACT(YEAR from "appointmentDate" AT TIME ZONE 'Europe/Paris') AS year
+        , EXTRACT(MONTH from "appointmentDate" AT TIME ZONE 'Europe/Paris') AS month`))
       .where('psychologistId', psychologistId)
       .whereNot(`${appointmentsTable}.deleted`, true)
-      .groupByRaw(`EXTRACT(YEAR from "appointmentDate")
-        , EXTRACT(MONTH from "appointmentDate")`)
+      .groupByRaw(`EXTRACT(YEAR from "appointmentDate" AT TIME ZONE 'Europe/Paris')
+        , EXTRACT(MONTH from "appointmentDate" AT TIME ZONE 'Europe/Paris')`)
       .orderBy([{ column: 'year', order: 'asc' }, { column: 'month', order: 'asc' }]);
     return query;
   } catch (err) {

--- a/db/appointments.js
+++ b/db/appointments.js
@@ -36,13 +36,13 @@ module.exports.getCountAppointmentsByYearMonth = async (psychologistId) => {
     const query = await knex(appointmentsTable)
       .select(knex.raw(`CAST(COUNT(*) AS INTEGER) AS "countAppointments"
         , "psychologistId"
-        , EXTRACT(YEAR from "appointmentDate" AT TIME ZONE 'Europe/Paris') AS year
-        , EXTRACT(MONTH from "appointmentDate" AT TIME ZONE 'Europe/Paris') AS month`))
+        , EXTRACT(YEAR from "appointmentDate") AS year
+        , EXTRACT(MONTH from "appointmentDate") AS month`))
       .where('psychologistId', psychologistId)
       .whereNot(`${appointmentsTable}.deleted`, true)
       .groupByRaw(`"psychologistId"
-        , EXTRACT(YEAR from "appointmentDate" AT TIME ZONE 'Europe/Paris')
-        , EXTRACT(MONTH from "appointmentDate" AT TIME ZONE 'Europe/Paris')`)
+        , EXTRACT(YEAR from "appointmentDate")
+        , EXTRACT(MONTH from "appointmentDate")`)
       .orderBy([{ column: 'year', order: 'asc' }, { column: 'month', order: 'asc' }]);
 
     return query;
@@ -78,9 +78,8 @@ module.exports.getMonthlyAppointmentsSummary = async (year, month) => {
         , ${dbPsychologists.psychologistsTable}."lastName"
         , ${dbPsychologists.psychologistsTable}."personalEmail"
         `))
-        .whereRaw(`EXTRACT(YEAR from ${appointmentsTable}."appointmentDate" AT TIME ZONE 'Europe/Paris') = ${year}`)
-        // eslint-disable-next-line max-len
-        .andWhereRaw(`EXTRACT(MONTH from ${appointmentsTable}."appointmentDate" AT TIME ZONE 'Europe/Paris') = ${month}`)
+        .whereRaw(`EXTRACT(YEAR from ${appointmentsTable}."appointmentDate") = ${year}`)
+        .andWhereRaw(`EXTRACT(MONTH from ${appointmentsTable}."appointmentDate") = ${month}`)
         .whereNot(`${appointmentsTable}.deleted`, true)
         .innerJoin(`${dbPsychologists.psychologistsTable}`,
           `${appointmentsTable}.psychologistId`,
@@ -111,12 +110,12 @@ module.exports.getCountPatientsByYearMonth = async (psychologistId) => {
   try {
     const query = await knex(appointmentsTable)
       .select(knex.raw(`CAST(COUNT(DISTINCT "patientId") AS INTEGER) AS "countPatients"
-        , EXTRACT(YEAR from "appointmentDate" AT TIME ZONE 'Europe/Paris') AS year
-        , EXTRACT(MONTH from "appointmentDate" AT TIME ZONE 'Europe/Paris') AS month`))
+        , EXTRACT(YEAR from "appointmentDate") AS year
+        , EXTRACT(MONTH from "appointmentDate") AS month`))
       .where('psychologistId', psychologistId)
       .whereNot(`${appointmentsTable}.deleted`, true)
-      .groupByRaw(`EXTRACT(YEAR from "appointmentDate" AT TIME ZONE 'Europe/Paris')
-        , EXTRACT(MONTH from "appointmentDate" AT TIME ZONE 'Europe/Paris')`)
+      .groupByRaw(`EXTRACT(YEAR from "appointmentDate")
+        , EXTRACT(MONTH from "appointmentDate")`)
       .orderBy([{ column: 'year', order: 'asc' }, { column: 'month', order: 'asc' }]);
     return query;
   } catch (err) {

--- a/frontend/src/components/Psychologist/Appointments/NewAppointment.jsx
+++ b/frontend/src/components/Psychologist/Appointments/NewAppointment.jsx
@@ -7,6 +7,7 @@ import Ariane from 'components/Ariane/Ariane';
 import Mail from 'components/Footer/Mail';
 import GlobalNotification from 'components/Notification/GlobalNotification';
 import agent from 'services/agent';
+import { convertLocalToUTCDate } from 'services/date';
 
 import { useStore } from 'stores/';
 
@@ -84,7 +85,7 @@ const NewAppointment = () => {
                 selected={date}
                 dateFormat="dd/MM/yyyy"
                 customInput={<DateInput />}
-                onChange={newDate => setDate(newDate)}
+                onChange={newDate => setDate(convertLocalToUTCDate(newDate))}
               />
             </div>
 

--- a/frontend/src/services/date.js
+++ b/frontend/src/services/date.js
@@ -105,10 +105,10 @@ module.exports.isSameMonth = isSameMonth;
 
 function convertLocalToUTCDate(date) {
   if (!date) {
-    return date
+    return date;
   }
-  date = new Date(date)
-  date = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()))
-  return date
+  let dateUTC = new Date(date);
+  dateUTC = new Date(Date.UTC(dateUTC.getFullYear(), dateUTC.getMonth(), dateUTC.getDate()));
+  return dateUTC;
 }
 module.exports.convertLocalToUTCDate = convertLocalToUTCDate;

--- a/frontend/src/services/date.js
+++ b/frontend/src/services/date.js
@@ -102,3 +102,13 @@ function isSameMonth(date1, date2) {
   return date1.getFullYear() === date2.getFullYear() && date1.getMonth() === date2.getMonth();
 }
 module.exports.isSameMonth = isSameMonth;
+
+function convertLocalToUTCDate(date) {
+  if (!date) {
+    return date
+  }
+  date = new Date(date)
+  date = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()))
+  return date
+}
+module.exports.convertLocalToUTCDate = convertLocalToUTCDate;


### PR DESCRIPTION
Envoi des dates du front vers le back en UTC comme c'était le cas avant la migration react.

Cela règle le problème des nouvelles séances déclarées mais une action devra être réalisée sur la base de données après le déploiement de cette PR afin de corriger les dates créées entre la migration react et cette PR : 
```
-- check the different timezone used to create appointments
select EXTRACT(HOUR from appointments."appointmentDate" at TIME zone 'UTC'), count(*), min("createdAt"), max("createdAt") from appointments 
group by EXTRACT(HOUR from appointments."appointmentDate" at TIME zone 'UTC');

-- for each timezone, add the missing hours to put them back in UTC timezone
update appointments 
set "appointmentDate" = "appointmentDate" + interval '4' HOUR
where EXTRACT(HOUR from appointments."appointmentDate" at TIME zone 'UTC') = '20';

update appointments 
set "appointmentDate" = "appointmentDate" + interval '2' HOUR
where EXTRACT(HOUR from appointments."appointmentDate" at TIME zone 'UTC') = '22';

update appointments 
set "appointmentDate" = "appointmentDate" + interval '1' HOUR
where EXTRACT(HOUR from appointments."appointmentDate" at TIME zone 'UTC') = '23';
```