### PR TITLE
Fix match psy to university script

### DIFF
--- a/scripts/matchSpecialPsyToUniversities.ts
+++ b/scripts/matchSpecialPsyToUniversities.ts
@@ -50,9 +50,10 @@ const matchPsyToUni = async (dryRun) => {
         return Promise.resolve();
       }
 
+      const currentUniversity = universities.find((uni) => uni.id === psy.assignedUniversityId);
       statsAssignmentDone.push({
         psy: psy.personalEmail,
-        uniFrom: universities.find((uni) => uni.id === psy.assignedUniversityId).name,
+        uniFrom: currentUniversity ? currentUniversity.name : '',
         uniTo: universityToAssign.name,
       });
 


### PR DESCRIPTION
If a psy has no assigned university yet, we had the following error: 
```
TypeError: Cannot read property 'name' of undefined
    at /home/sricardo/dev/betagouv/sante-psy/scripts/matchSpecialPsyToUniversities.ts:55:81
```