### PR TITLE
Use date in db instead of datetime

### DIFF
--- a/migrations/20210806091509_use-date.ts
+++ b/migrations/20210806091509_use-date.ts
@@ -1,0 +1,31 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void[]> {
+  const alters = [knex.schema.alterTable('appointments', (table) => {
+    table.date('appointmentDate').alter();
+  }),
+  knex.schema.alterTable('psychologists', (table) => {
+    table.date('inactiveUntil').alter();
+  }),
+  knex.schema.alterTable('patients', (table) => {
+    table.date('dateOfBirth').alter();
+  }),
+  ];
+
+  return Promise.all(alters);
+}
+
+export async function down(knex: Knex): Promise<void[]> {
+  const alters = [knex.schema.alterTable('appointments', (table) => {
+    table.dateTime('appointmentDate').alter();
+  }),
+  knex.schema.alterTable('psychologists', (table) => {
+    table.dateTime('inactiveUntil').alter();
+  }),
+  knex.schema.alterTable('patients', (table) => {
+    table.dateTime('dateOfBirth').alter();
+  }),
+  ];
+
+  return Promise.all(alters);
+}

--- a/test/db/psychologists.spec.ts
+++ b/test/db/psychologists.spec.ts
@@ -433,6 +433,7 @@ describe('DB Psychologists', () => {
       const now = new Date();
       const date = new Date();
       date.setDate(date.getDate() + 50);
+      date.setHours(0, 0, 0, 0);
 
       await dbPsychologists.suspend(activePsy.dossierNumber, date, 'because i say so');
 
@@ -482,6 +483,7 @@ describe('DB Psychologists', () => {
       psy.selfModified.should.be.equal(false);
       assert.isNull(psy.inactiveUntil);
 
+      tomorrow.setHours(0, 0, 0, 0);
       psy = await dbPsychologists.getById(inactivePsy3.dossierNumber);
       psy.active.should.be.equal(false);
       psy.selfModified.should.be.equal(false);


### PR DESCRIPTION
With the current react date picker it's impossible to have a clean date (it always take in account the TZ of the user which we don't want)

solutions: 
- use another one (didn't look a lot but no obvious choice), it needs to be very customisable and allow to use a proper date at midnight GMT
- Create a react dsfr one (might me long...)
- keep it like that