### PR TITLE
Added new environment variable to setup a trace sample rate 

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -46,3 +46,6 @@ CRISP_KEY='mouse'
 
 # Api address min score 
 MIN_SCORE_ADDRESS='0.55'
+
+# Sentry
+SENTRY_TRACE_SAMPLE_RATE='0.05'

--- a/.env.sample
+++ b/.env.sample
@@ -57,3 +57,6 @@ FEATURE_CHECK_MULTIPLE_FILES=false
 
 # Api address min score 
 MIN_SCORE_ADDRESS='0.55'
+
+# Sentry
+SENTRY_TRACE_SAMPLE_RATE='0.05'

--- a/utils/sentry.ts
+++ b/utils/sentry.ts
@@ -15,6 +15,7 @@ const initCaptureConsole = (): void => {
     integrations: [
       new sentryIntegrations.CaptureConsole({ levels: logLevel }),
     ],
+    tracesSampleRate: parseFloat(process.env.SENTRY_TRACE_SAMPLE_RATE),
   });
 };
 


### PR DESCRIPTION
Added new environment variable to setup a trace sample rate  to limit the number of calls to sentry.
there are too many calls and the server is quickly saturated.