### PR TITLE
Feat/matomo track eligibility check

### DIFF
--- a/frontend/src/components/Eligibility/StudentEligibility.jsx
+++ b/frontend/src/components/Eligibility/StudentEligibility.jsx
@@ -51,7 +51,7 @@ const StudentEligibility = () => {
       _paq.push(['trackEvent', 'Student', 'nextStepEligibility']);
     }
     navigate('/#anchor-prescription-letter');
-  }
+  };
 
   const onChange = ine => {
     setError(false);

--- a/frontend/src/components/Eligibility/StudentEligibility.jsx
+++ b/frontend/src/components/Eligibility/StudentEligibility.jsx
@@ -26,6 +26,11 @@ const StudentEligibility = () => {
   const submit = e => {
     e.preventDefault();
     setIsLoading(true);
+
+    if (__MATOMO__) {
+      _paq.push(['trackEvent', 'Student', 'checkEligibility']);
+    }
+
     agent.Eligibility.get({ ine: INE })
       .then(response => {
         setIsEligible(response);

--- a/frontend/src/components/Eligibility/StudentEligibility.jsx
+++ b/frontend/src/components/Eligibility/StudentEligibility.jsx
@@ -46,6 +46,13 @@ const StudentEligibility = () => {
       });
   };
 
+  const handleNextStep = () => {
+    if (__MATOMO__) {
+      _paq.push(['trackEvent', 'Student', 'nextStepEligibility']);
+    }
+    navigate('/#anchor-prescription-letter');
+  }
+
   const onChange = ine => {
     setError(false);
     setErrorMessage('');
@@ -173,7 +180,7 @@ const StudentEligibility = () => {
               </p>
               <Button
                 disabled={isLoading}
-                onClick={() => navigate('/#anchor-prescription-letter')}
+                onClick={handleNextStep}
               >
                 Étape suivante
                 <Icon name="ri-arrow-right-s-fill" />

--- a/frontend/src/components/Psychologist/Reimbursement/Billing.jsx
+++ b/frontend/src/components/Psychologist/Reimbursement/Billing.jsx
@@ -152,7 +152,7 @@ const Billing = () => {
               </b>
               étudiants.
             </p>
-            <p>La première séance par cycle avec un étudiant est facturée 40€, les suivantes à 30€.</p>
+            <p>À partir du 1er janvier 2024, la première séance par cycle avec un étudiant est facturée 40€, les suivantes à 30€.</p>
           </>
         ) : (
           <p className="fr-mb-2w" id="no-appointments">


### PR DESCRIPTION
- Ajout d'un tracker matomo lors du clique sur le bouton de vérification éligibilité
- Modification de wording dans la page facturation pour préciser que la 1er séance à 40€ s'applique à partir du 1er janvier 2024