### PR TITLE
feat: Trouver la téléconsultation disponible le plus tôt

### DIFF
--- a/controllers/teleconsultationRapideController.ts
+++ b/controllers/teleconsultationRapideController.ts
@@ -1,23 +1,32 @@
 import { Request, Response } from 'express';
-import teleconsultationCache from '../db/teleconsultationCache';
+import teleconsultationSlots from '../db/teleconsultationCache';
 import { runFullRefresh, verifySlots, isDoctolibBlocked } from '../services/doctolibAvailability';
 
 const CACHE_TTL_MS = 15 * 60 * 1000; // 15 minutes
+const RESULTS_COUNT = 5;
+
+/** Formate les SlotEntry en objet lisible par le frontend (slotDatetime → nextSlot). */
+const formatResults = (entries: Awaited<ReturnType<typeof teleconsultationSlots.getTopN>>) =>
+  entries.map(e => ({
+    psychologistId: e.psychologistId,
+    psychologistName: e.psychologistName,
+    doctolibUrl: e.doctolibUrl,
+    nextSlot: e.slotDatetime,
+  }));
 
 const getFastestTeleconsultation = async (_req: Request, res: Response): Promise<void> => {
-  // Si Doctolib bloque les requêtes serveur, on ne renvoie rien
+  // Si Doctolib bloque les requêtes serveur, on masque le bouton
   if (isDoctolibBlocked()) {
     res.json({ results: [], stale: false, blocked: true });
     return;
   }
 
-  const top5 = await teleconsultationCache.getTop5();
-  const lastRefreshAt = await teleconsultationCache.getLastFullRefreshAt();
-
+  const lastRefreshAt = await teleconsultationSlots.getLastFullRefreshAt();
   const isStale =
     !lastRefreshAt || Date.now() - new Date(lastRefreshAt).getTime() > CACHE_TTL_MS;
 
-  const isEmpty = top5.length === 0;
+  const topEntries = await teleconsultationSlots.getTopN(RESULTS_COUNT);
+  const isEmpty = topEntries.length === 0;
 
   if (isEmpty) {
     // Premier appel : on attend le refresh complet avant de répondre
@@ -28,35 +37,31 @@ const getFastestTeleconsultation = async (_req: Request, res: Response): Promise
       return;
     }
 
-    const results = await teleconsultationCache.getTop5();
-    res.json({ results, stale: false, blocked: false });
+    const results = await teleconsultationSlots.getTopN(RESULTS_COUNT);
+    res.json({ results: formatResults(results), stale: false, blocked: false });
     return;
   }
 
   if (isStale) {
-    // Cache périmé : on répond immédiatement avec les données en cache
-    // et on lance le refresh en arrière-plan
-    res.json({ results: top5, stale: true, blocked: false });
-    // fire-and-forget
+    // Cache périmé : réponse immédiate + refresh en arrière-plan
+    res.json({ results: formatResults(topEntries), stale: true, blocked: false });
     runFullRefresh().catch(err => console.error('Erreur refresh Doctolib en arrière-plan :', err));
     return;
   }
 
-  // Cache frais (< 15 min) : on vérifie que les 5 créneaux existent encore.
-  // verifySlots met à jour le cache (nextSlot = null pour les créneaux expirés).
-  // On relit ensuite getTop5() pour que les psys sans créneau soient automatiquement
-  // remplacés par les suivants dans le cache (ex. : si le #3 n'a plus de dispo,
-  // le #6 remonte à sa place).
-  await verifySlots(top5);
+  // Cache frais : vérification de la liste plate (supprime les créneaux pris,
+  // re-fetche les psys à compteur 0, met à jour le cache)
+  const blocked = await verifySlots();
 
-  if (isDoctolibBlocked()) {
-    // La vérification a détecté un blocage : on renvoie le cache tel quel
-    res.json({ results: top5, stale: false, blocked: true });
+  if (blocked) {
+    res.json({ results: formatResults(topEntries), stale: false, blocked: true });
     return;
   }
 
-  const results = await teleconsultationCache.getTop5();
-  res.json({ results, stale: false, blocked: false });
+  // Relit le top-5 après mise à jour : si un créneau est parti, son remplaçant
+  // (même psy ou autre psy) est automatiquement remonté
+  const results = await teleconsultationSlots.getTopN(RESULTS_COUNT);
+  res.json({ results: formatResults(results), stale: false, blocked: false });
 };
 
 export default { getFastestTeleconsultation };

--- a/controllers/teleconsultationRapideController.ts
+++ b/controllers/teleconsultationRapideController.ts
@@ -1,10 +1,16 @@
 import { Request, Response } from 'express';
 import teleconsultationCache from '../db/teleconsultationCache';
-import { runFullRefresh, verifySlots } from '../services/doctolibAvailability';
+import { runFullRefresh, verifySlots, isDoctolibBlocked } from '../services/doctolibAvailability';
 
 const CACHE_TTL_MS = 15 * 60 * 1000; // 15 minutes
 
 const getFastestTeleconsultation = async (_req: Request, res: Response): Promise<void> => {
+  // Si Doctolib bloque les requêtes serveur, on ne renvoie rien
+  if (isDoctolibBlocked()) {
+    res.json({ results: [], stale: false, blocked: true });
+    return;
+  }
+
   const top5 = await teleconsultationCache.getTop5();
   const lastRefreshAt = await teleconsultationCache.getLastFullRefreshAt();
 
@@ -16,15 +22,21 @@ const getFastestTeleconsultation = async (_req: Request, res: Response): Promise
   if (isEmpty) {
     // Premier appel : on attend le refresh complet avant de répondre
     await runFullRefresh();
+
+    if (isDoctolibBlocked()) {
+      res.json({ results: [], stale: false, blocked: true });
+      return;
+    }
+
     const results = await teleconsultationCache.getTop5();
-    res.json({ results, stale: false });
+    res.json({ results, stale: false, blocked: false });
     return;
   }
 
   if (isStale) {
     // Cache périmé : on répond immédiatement avec les données en cache
     // et on lance le refresh en arrière-plan
-    res.json({ results: top5, stale: true });
+    res.json({ results: top5, stale: true, blocked: false });
     // fire-and-forget
     runFullRefresh().catch(err => console.error('Erreur refresh Doctolib en arrière-plan :', err));
     return;
@@ -32,7 +44,14 @@ const getFastestTeleconsultation = async (_req: Request, res: Response): Promise
 
   // Cache frais (< 15 min) : on vérifie que les 5 créneaux existent encore
   const verified = await verifySlots(top5);
-  res.json({ results: verified, stale: false });
+
+  if (isDoctolibBlocked()) {
+    // La vérification a détecté un blocage : on renvoie le cache tel quel
+    res.json({ results: top5, stale: false, blocked: true });
+    return;
+  }
+
+  res.json({ results: verified, stale: false, blocked: false });
 };
 
 export default { getFastestTeleconsultation };

--- a/controllers/teleconsultationRapideController.ts
+++ b/controllers/teleconsultationRapideController.ts
@@ -42,8 +42,12 @@ const getFastestTeleconsultation = async (_req: Request, res: Response): Promise
     return;
   }
 
-  // Cache frais (< 15 min) : on vérifie que les 5 créneaux existent encore
-  const verified = await verifySlots(top5);
+  // Cache frais (< 15 min) : on vérifie que les 5 créneaux existent encore.
+  // verifySlots met à jour le cache (nextSlot = null pour les créneaux expirés).
+  // On relit ensuite getTop5() pour que les psys sans créneau soient automatiquement
+  // remplacés par les suivants dans le cache (ex. : si le #3 n'a plus de dispo,
+  // le #6 remonte à sa place).
+  await verifySlots(top5);
 
   if (isDoctolibBlocked()) {
     // La vérification a détecté un blocage : on renvoie le cache tel quel
@@ -51,7 +55,8 @@ const getFastestTeleconsultation = async (_req: Request, res: Response): Promise
     return;
   }
 
-  res.json({ results: verified, stale: false, blocked: false });
+  const results = await teleconsultationCache.getTop5();
+  res.json({ results, stale: false, blocked: false });
 };
 
 export default { getFastestTeleconsultation };

--- a/controllers/teleconsultationRapideController.ts
+++ b/controllers/teleconsultationRapideController.ts
@@ -1,0 +1,38 @@
+import { Request, Response } from 'express';
+import teleconsultationCache from '../db/teleconsultationCache';
+import { runFullRefresh, verifySlots } from '../services/doctolibAvailability';
+
+const CACHE_TTL_MS = 15 * 60 * 1000; // 15 minutes
+
+const getFastestTeleconsultation = async (_req: Request, res: Response): Promise<void> => {
+  const top5 = await teleconsultationCache.getTop5();
+  const lastRefreshAt = await teleconsultationCache.getLastFullRefreshAt();
+
+  const isStale =
+    !lastRefreshAt || Date.now() - new Date(lastRefreshAt).getTime() > CACHE_TTL_MS;
+
+  const isEmpty = top5.length === 0;
+
+  if (isEmpty) {
+    // Premier appel : on attend le refresh complet avant de répondre
+    await runFullRefresh();
+    const results = await teleconsultationCache.getTop5();
+    res.json({ results, stale: false });
+    return;
+  }
+
+  if (isStale) {
+    // Cache périmé : on répond immédiatement avec les données en cache
+    // et on lance le refresh en arrière-plan
+    res.json({ results: top5, stale: true });
+    // fire-and-forget
+    runFullRefresh().catch(err => console.error('Erreur refresh Doctolib en arrière-plan :', err));
+    return;
+  }
+
+  // Cache frais (< 15 min) : on vérifie que les 5 créneaux existent encore
+  const verified = await verifySlots(top5);
+  res.json({ results: verified, stale: false });
+};
+
+export default { getFastestTeleconsultation };

--- a/db/psychologists.ts
+++ b/db/psychologists.ts
@@ -448,9 +448,24 @@ const seeTutorial = async (dossierNumber: string): Promise<number> => {
   }
 };
 
+const getAllAcceptedWithTeleconsultation = async (): Promise<Psychologist[]> => {
+  try {
+    return db(psychologistsTable)
+      .where('state', DossierState.accepte)
+      .where('teleconsultation', true)
+      .whereNotNull('appointmentLink')
+      .whereNot('appointmentLink', '')
+      .select('dossierNumber', 'firstNames', 'lastName', 'appointmentLink', 'website');
+  } catch (err) {
+    console.error('Impossible de récupérer les psychologistes avec téléconsultation', err);
+    throw new Error('Impossible de récupérer les psychologistes avec téléconsultation');
+  }
+};
+
 export default {
   getAllActive,
   getAllActiveByAvailability,
+  getAllAcceptedWithTeleconsultation,
   getById,
   getAcceptedByEmail,
   getNotYetAcceptedByEmail,

--- a/db/tables.ts
+++ b/db/tables.ts
@@ -8,3 +8,4 @@ export const suspensionReasonsTable = 'suspension_reasons';
 export const lastConnectionsTable = 'last_connections';
 export const studentsTable = 'students';
 export const studentsNewsletterTable = 'students_newsletter';
+export const teleconsultationCacheTable = 'teleconsultation_cache';

--- a/db/tables.ts
+++ b/db/tables.ts
@@ -8,4 +8,4 @@ export const suspensionReasonsTable = 'suspension_reasons';
 export const lastConnectionsTable = 'last_connections';
 export const studentsTable = 'students';
 export const studentsNewsletterTable = 'students_newsletter';
-export const teleconsultationCacheTable = 'teleconsultation_cache';
+export const teleconsultationSlotsTable = 'teleconsultation_slots';

--- a/db/teleconsultationCache.ts
+++ b/db/teleconsultationCache.ts
@@ -10,8 +10,29 @@ export type SlotEntry = {
   lastFullRefreshAt: Date | null;
 };
 
-/** Retourne les N prochains créneaux futurs triés par date croissante (liste plate). */
-const getTopN = async (n: number): Promise<SlotEntry[]> => db(teleconsultationSlotsTable)
+/**
+ * Retourne les N psys avec le créneau le plus tôt, triés par date croissante.
+ * Un seul créneau par psy (le plus proche) — utilise DISTINCT ON PostgreSQL.
+ */
+const getTopN = async (n: number): Promise<SlotEntry[]> => db
+  .with('earliest', qb =>
+    qb
+      .distinctOn('psychologistId')
+      .from(teleconsultationSlotsTable)
+      .where('slotDatetime', '>=', new Date())
+      .orderBy('psychologistId')
+      .orderBy('slotDatetime', 'asc'),
+  )
+  .select('*')
+  .from('earliest')
+  .orderBy('slotDatetime', 'asc')
+  .limit(n);
+
+/**
+ * Retourne tous les créneaux futurs triés par date croissante (liste plate, multi-psy).
+ * Utilisé en interne par le service de vérification.
+ */
+const getFlatTopN = async (n: number): Promise<SlotEntry[]> => db(teleconsultationSlotsTable)
   .where('slotDatetime', '>=', new Date())
   .orderBy('slotDatetime', 'asc')
   .limit(n);
@@ -81,6 +102,7 @@ const deleteAll = async (): Promise<void> => {
 
 export default {
   getTopN,
+  getFlatTopN,
   getSlotCount,
   getLastFullRefreshAt,
   replaceSlots,

--- a/db/teleconsultationCache.ts
+++ b/db/teleconsultationCache.ts
@@ -1,74 +1,90 @@
-import { teleconsultationCacheTable } from './tables';
+import { teleconsultationSlotsTable } from './tables';
 import db from './db';
 
-export type CacheEntry = {
+export type SlotEntry = {
   id: number;
   psychologistId: string;
   psychologistName: string;
   doctolibUrl: string;
-  nextSlot: Date | null;
-  lastSlotCheckedAt: Date | null;
+  slotDatetime: Date;
   lastFullRefreshAt: Date | null;
 };
 
-const getTop5 = async (): Promise<CacheEntry[]> => db(teleconsultationCacheTable)
-  .whereNotNull('nextSlot')
-  .where('nextSlot', '>=', new Date())
-  .orderBy('nextSlot', 'asc')
-  .limit(5);
+/** Retourne les N prochains créneaux futurs triés par date croissante (liste plate). */
+const getTopN = async (n: number): Promise<SlotEntry[]> => db(teleconsultationSlotsTable)
+  .where('slotDatetime', '>=', new Date())
+  .orderBy('slotDatetime', 'asc')
+  .limit(n);
 
-const getLastFullRefreshAt = async (): Promise<Date | null> => {
-  const row = await db(teleconsultationCacheTable)
-    .whereNotNull('lastFullRefreshAt')
-    .orderBy('lastFullRefreshAt', 'desc')
-    .select('lastFullRefreshAt')
+/** Retourne le nombre de créneaux futurs en cache pour un psy donné. */
+const getSlotCount = async (psychologistId: string): Promise<number> => {
+  const row = await db(teleconsultationSlotsTable)
+    .where({ psychologistId })
+    .where('slotDatetime', '>=', new Date())
+    .count('id as count')
     .first();
-  return row ? row.lastFullRefreshAt : null;
+  return Number(row?.count ?? 0);
 };
 
-const upsertSlot = async (
+/** Timestamp du dernier refresh complet (max de lastFullRefreshAt sur toute la table). */
+const getLastFullRefreshAt = async (): Promise<Date | null> => {
+  const row = await db(teleconsultationSlotsTable)
+    .whereNotNull('lastFullRefreshAt')
+    .max('lastFullRefreshAt as lastFullRefreshAt')
+    .first();
+  return row?.lastFullRefreshAt ?? null;
+};
+
+/**
+ * Remplace tous les créneaux d'un psy par les nouveaux slots fournis.
+ * Si `isFullRefresh` est true, renseigne lastFullRefreshAt sur chaque ligne insérée.
+ */
+const replaceSlots = async (
   psychologistId: string,
   psychologistName: string,
   doctolibUrl: string,
-  nextSlot: string | null,
+  slots: string[],
   isFullRefresh = false,
 ): Promise<void> => {
-  const existing = await db(teleconsultationCacheTable)
-    .where({ psychologistId })
-    .first();
+  await db(teleconsultationSlotsTable).where({ psychologistId }).delete();
+
+  if (slots.length === 0) return;
 
   const now = new Date();
-  const updateData: Record<string, unknown> = {
+  const rows = slots.map(slot => ({
+    psychologistId,
     psychologistName,
     doctolibUrl,
-    nextSlot: nextSlot || null,
-    lastSlotCheckedAt: now,
+    slotDatetime: new Date(slot),
+    lastFullRefreshAt: isFullRefresh ? now : null,
+    created_at: now,
     updated_at: now,
-  };
-  if (isFullRefresh) {
-    updateData.lastFullRefreshAt = now;
-  }
+  }));
 
-  if (existing) {
-    await db(teleconsultationCacheTable)
-      .where({ psychologistId })
-      .update(updateData);
-  } else {
-    await db(teleconsultationCacheTable).insert({
-      psychologistId,
-      ...updateData,
-      created_at: now,
-    });
-  }
+  await db(teleconsultationSlotsTable).insert(rows);
 };
 
+/** Supprime un créneau précis par son id (créneau confirmé comme pris). */
+const deleteSlot = async (id: number): Promise<void> => {
+  await db(teleconsultationSlotsTable).where({ id }).delete();
+};
+
+/** Supprime tous les créneaux d'un psy (compteur tombé à 0 ou profil introuvable). */
+const deleteAllForPsy = async (psychologistId: string): Promise<void> => {
+  await db(teleconsultationSlotsTable).where({ psychologistId }).delete();
+};
+
+/** Vide entièrement la table (avant un refresh complet). */
 const deleteAll = async (): Promise<void> => {
-  await db(teleconsultationCacheTable).delete();
+  await db(teleconsultationSlotsTable).delete();
 };
 
 export default {
-  getTop5,
+  getTopN,
+  getSlotCount,
   getLastFullRefreshAt,
-  upsertSlot,
+  replaceSlots,
+  deleteSlot,
+  deleteAllForPsy,
   deleteAll,
 };

--- a/db/teleconsultationCache.ts
+++ b/db/teleconsultationCache.ts
@@ -1,0 +1,74 @@
+import { teleconsultationCacheTable } from './tables';
+import db from './db';
+
+export type CacheEntry = {
+  id: number;
+  psychologistId: string;
+  psychologistName: string;
+  doctolibUrl: string;
+  nextSlot: Date | null;
+  lastSlotCheckedAt: Date | null;
+  lastFullRefreshAt: Date | null;
+};
+
+const getTop5 = async (): Promise<CacheEntry[]> => db(teleconsultationCacheTable)
+  .whereNotNull('nextSlot')
+  .where('nextSlot', '>=', new Date())
+  .orderBy('nextSlot', 'asc')
+  .limit(5);
+
+const getLastFullRefreshAt = async (): Promise<Date | null> => {
+  const row = await db(teleconsultationCacheTable)
+    .whereNotNull('lastFullRefreshAt')
+    .orderBy('lastFullRefreshAt', 'desc')
+    .select('lastFullRefreshAt')
+    .first();
+  return row ? row.lastFullRefreshAt : null;
+};
+
+const upsertSlot = async (
+  psychologistId: string,
+  psychologistName: string,
+  doctolibUrl: string,
+  nextSlot: string | null,
+  isFullRefresh = false,
+): Promise<void> => {
+  const existing = await db(teleconsultationCacheTable)
+    .where({ psychologistId })
+    .first();
+
+  const now = new Date();
+  const updateData: Record<string, unknown> = {
+    psychologistName,
+    doctolibUrl,
+    nextSlot: nextSlot || null,
+    lastSlotCheckedAt: now,
+    updated_at: now,
+  };
+  if (isFullRefresh) {
+    updateData.lastFullRefreshAt = now;
+  }
+
+  if (existing) {
+    await db(teleconsultationCacheTable)
+      .where({ psychologistId })
+      .update(updateData);
+  } else {
+    await db(teleconsultationCacheTable).insert({
+      psychologistId,
+      ...updateData,
+      created_at: now,
+    });
+  }
+};
+
+const deleteAll = async (): Promise<void> => {
+  await db(teleconsultationCacheTable).delete();
+};
+
+export default {
+  getTop5,
+  getLastFullRefreshAt,
+  upsertSlot,
+  deleteAll,
+};

--- a/frontend/src/components/PsyListing/PsyListing.jsx
+++ b/frontend/src/components/PsyListing/PsyListing.jsx
@@ -13,6 +13,7 @@ import { useStore } from 'stores/';
 import GlobalNotification from 'components/Notification/GlobalNotification';
 import PsyTable from './PsyTable';
 import NoResultPsyTable from './NoResultPsyTable';
+import TeleconsultationRapide from './TeleconsultationRapide';
 
 import styles from './psyListing.cssmodule.scss';
 
@@ -295,9 +296,10 @@ const PsyListing = () => {
         </div>
         <Alert
           type="warning"
-          title="Vous n‘avez aucune avance de frais à prévoir"
+          title="Vous n’avez aucune avance de frais à prévoir"
           description="Le psychologue ne doit en aucun cas vous demander un complément financier ou une avance."
         />
+        <TeleconsultationRapide />
         <PsyTable
           page={page}
           setPage={handlePageChange}

--- a/frontend/src/components/PsyListing/TeleconsultationRapide.jsx
+++ b/frontend/src/components/PsyListing/TeleconsultationRapide.jsx
@@ -1,0 +1,141 @@
+import React, { useState } from 'react';
+import { Alert, Button } from '@dataesr/react-dsfr';
+import agent from 'services/agent';
+
+const DAYS_FR = ['dimanche', 'lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi', 'samedi'];
+const MONTHS_FR = [
+  'janvier', 'février', 'mars', 'avril', 'mai', 'juin',
+  'juillet', 'août', 'septembre', 'octobre', 'novembre', 'décembre',
+];
+
+const formatSlot = isoSlot => {
+  try {
+    const d = new Date(isoSlot);
+    const day = DAYS_FR[d.getDay()];
+    const month = MONTHS_FR[d.getMonth()];
+    const hours = String(d.getHours()).padStart(2, '0');
+    const minutes = String(d.getMinutes()).padStart(2, '0');
+    return `${day} ${d.getDate()} ${month} ${d.getFullYear()} à ${hours}h${minutes}`;
+  } catch {
+    return isoSlot;
+  }
+};
+
+const TeleconsultationRapide = () => {
+  const [loading, setLoading] = useState(false);
+  const [results, setResults] = useState(null);
+  const [stale, setStale] = useState(false);
+  const [error, setError] = useState(false);
+
+  const handleClick = async () => {
+    setLoading(true);
+    setError(false);
+    try {
+      const data = await agent.Psychologist.fastestTeleconsultation();
+      setResults(data.results);
+      setStale(data.stale);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fr-mb-4w">
+      <Button
+        onClick={handleClick}
+        disabled={loading}
+        icon="ri-time-line"
+        iconPosition="left"
+        secondary
+      >
+        {loading ? 'Recherche en cours…' : 'Voir les premières disponibilités en téléconsultation'}
+      </Button>
+
+      {loading && (
+        <p className="fr-mt-2w fr-text--sm fr-hint-text">
+          Interrogation de Doctolib… Cette opération peut prendre quelques secondes.
+        </p>
+      )}
+
+      {error && (
+        <Alert
+          className="fr-mt-2w"
+          type="error"
+          description="Impossible de récupérer les disponibilités pour le moment. Veuillez réessayer."
+        />
+      )}
+
+      {stale && !loading && (
+        <Alert
+          className="fr-mt-2w"
+          type="info"
+          description="Ces résultats proviennent du dernier scan (il y a plus de 15 minutes). Une mise à jour est en cours en arrière-plan."
+        />
+      )}
+
+      {results && results.length === 0 && !loading && (
+        <Alert
+          className="fr-mt-2w"
+          type="warning"
+          description="Aucun créneau de téléconsultation disponible n'a été trouvé pour le moment."
+        />
+      )}
+
+      {results && results.length > 0 && (
+        <div className="fr-mt-3w">
+          <h3 className="fr-h5">
+            {results.length === 1
+              ? '1 psychologue disponible en téléconsultation'
+              : `${results.length} psychologues disponibles en téléconsultation`}
+          </h3>
+          <ul className="fr-raw-list">
+            {results.map((psy, index) => (
+              <li key={psy.psychologistId} className="fr-mb-2w">
+                <div className="fr-card fr-card--sm fr-card--no-arrow fr-p-2w">
+                  <div className="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
+                    <div className="fr-col-auto">
+                      <span
+                        className="fr-badge fr-badge--blue-cumulus"
+                        aria-label={`Rang ${index + 1}`}
+                      >
+                        {`#${index + 1}`}
+                      </span>
+                    </div>
+                    <div className="fr-col">
+                      <p className="fr-text--bold fr-mb-0">{psy.psychologistName}</p>
+                      {psy.nextSlot ? (
+                        <p className="fr-text--sm fr-mb-0">
+                          <span className="fr-icon-calendar-line fr-icon--sm" aria-hidden="true" />
+                          {' '}
+                          {formatSlot(psy.nextSlot)}
+                        </p>
+                      ) : (
+                        <p className="fr-text--sm fr-mb-0 fr-hint-text">
+                          Disponibilité non vérifiée
+                        </p>
+                      )}
+                    </div>
+                    <div className="fr-col-auto">
+                      <a
+                        href={psy.doctolibUrl}
+                        className="fr-btn fr-btn--sm"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Prendre rendez-vous
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TeleconsultationRapide;

--- a/frontend/src/components/PsyListing/TeleconsultationRapide.jsx
+++ b/frontend/src/components/PsyListing/TeleconsultationRapide.jsx
@@ -25,6 +25,7 @@ const TeleconsultationRapide = () => {
   const [loading, setLoading] = useState(false);
   const [results, setResults] = useState(null);
   const [stale, setStale] = useState(false);
+  const [blocked, setBlocked] = useState(false);
   const [error, setError] = useState(false);
 
   const handleClick = async () => {
@@ -32,6 +33,11 @@ const TeleconsultationRapide = () => {
     setError(false);
     try {
       const data = await agent.Psychologist.fastestTeleconsultation();
+      if (data.blocked) {
+        setBlocked(true);
+        return;
+      }
+      setBlocked(false);
       setResults(data.results);
       setStale(data.stale);
     } catch {
@@ -40,6 +46,11 @@ const TeleconsultationRapide = () => {
       setLoading(false);
     }
   };
+
+  // Si Doctolib bloque le serveur, on masque entièrement le composant
+  if (blocked) {
+    return null;
+  }
 
   return (
     <div className="fr-mb-4w">

--- a/frontend/src/services/agent.js
+++ b/frontend/src/services/agent.js
@@ -77,6 +77,7 @@ const Patient = {
 const Psychologist = {
   activate: () => client.post(`/psychologist/${store.userStore.user.dossierNumber}/activate`),
   find: filters => client.get('/trouver-un-psychologue/reduced', { params: { filters } }),
+  fastestTeleconsultation: () => client.get('/teleconsultation-rapide'),
   getProfile: id => client.get(`/psychologist/${id || store.userStore.user.dossierNumber}`),
   suspend: (reason, date) => client
     .post(`/psychologist/${store.userStore.user.dossierNumber}/suspend`, { reason, date }),

--- a/migrations/20260328120000_create_teleconsultation_cache.ts
+++ b/migrations/20260328120000_create_teleconsultation_cache.ts
@@ -1,0 +1,20 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('teleconsultation_cache', (table) => {
+    table.increments('id');
+    table.string('psychologistId').notNullable();
+    table.string('psychologistName').notNullable();
+    table.string('doctolibUrl').notNullable();
+    table.timestamp('nextSlot').nullable();
+    table.timestamp('lastSlotCheckedAt').nullable();
+    table.timestamp('lastFullRefreshAt').nullable();
+    table.timestamps(true, true);
+    table.index(['nextSlot']);
+    table.index(['lastFullRefreshAt']);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTable('teleconsultation_cache');
+}

--- a/migrations/20260328130000_replace_teleconsultation_cache.ts
+++ b/migrations/20260328130000_replace_teleconsultation_cache.ts
@@ -1,0 +1,39 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  // Supprime l'ancienne table (un seul next_slot par psy)
+  if (await knex.schema.hasTable('teleconsultation_cache')) {
+    await knex.schema.dropTable('teleconsultation_cache');
+  }
+
+  // Nouvelle table : un créneau par ligne, liste plate triée par date
+  await knex.schema.createTable('teleconsultation_slots', (table) => {
+    table.increments('id');
+    table.string('psychologistId').notNullable();
+    table.string('psychologistName').notNullable();
+    table.string('doctolibUrl').notNullable();
+    table.timestamp('slotDatetime').notNullable();
+    table.timestamp('lastFullRefreshAt').nullable();
+    table.timestamps(true, true);
+    table.index(['slotDatetime']);
+    table.index(['psychologistId']);
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTableIfExists('teleconsultation_slots');
+
+  // Recrée l'ancienne table
+  await knex.schema.createTable('teleconsultation_cache', (table) => {
+    table.increments('id');
+    table.string('psychologistId').notNullable();
+    table.string('psychologistName').notNullable();
+    table.string('doctolibUrl').notNullable();
+    table.timestamp('nextSlot').nullable();
+    table.timestamp('lastSlotCheckedAt').nullable();
+    table.timestamp('lastFullRefreshAt').nullable();
+    table.timestamps(true, true);
+    table.index(['nextSlot']);
+    table.index(['lastFullRefreshAt']);
+  });
+}

--- a/routers/unprotected.ts
+++ b/routers/unprotected.ts
@@ -13,6 +13,7 @@ import contactController from '../controllers/contactController';
 import studentNewsletterController from '../controllers/studentNewsletterController';
 import studentSignInController from '../controllers/studentSignInController';
 import uploadCertificate from '../middlewares/uploadCertificate';
+import teleconsultationRapideController from '../controllers/teleconsultationRapideController';
 
 const router = express.Router();
 
@@ -138,6 +139,9 @@ router.get(
 );
 // The other route is open to the public to get all psys (do not delete !)
 router.get('/trouver-un-psychologue', psyListingController.getFullActive);
+
+// Fastest teleconsultation availability
+router.get('/teleconsultation-rapide', teleconsultationRapideController.getFastestTeleconsultation);
 
 router.get('/statistics', statisticsController.getAll);
 router.get('/psychologist/:psyId', psyProfileController.getValidators, psyProfileController.get);

--- a/services/doctolibAvailability.ts
+++ b/services/doctolibAvailability.ts
@@ -8,20 +8,26 @@
  * Détection de blocage : si >= 80 % des 10 premières requêtes SSF d'un refresh
  * retournent 403, on positionne doctolibBlocked = true. Le flag se réinitialise
  * au prochain refresh complet si les requêtes repassent.
+ *
+ * Cache multi-créneaux : pour chaque psy, on stocke TOUS les créneaux retournés
+ * par l'API (limit=5 jours). La vérification itère la liste plate triée par date ;
+ * un appel Doctolib n'est fait qu'au premier contact avec un psy par passe. Si le
+ * compteur d'un psy tombe à 0, on le re-fetche immédiatement.
  */
 
 import dbPsychologists from '../db/psychologists';
-import teleconsultationCache, { CacheEntry } from '../db/teleconsultationCache';
+import teleconsultationSlots from '../db/teleconsultationCache';
 import { Psychologist } from '../types/Psychologist';
 
 const DOCTOLIB_BASE = 'https://www.doctolib.fr';
 const SSF_URL = `${DOCTOLIB_BASE}/online_booking/api/slot_selection_funnel/v1/info.json`;
 const AVAIL_URL = `${DOCTOLIB_BASE}/availabilities.json`;
 const RATE_MS = 250; // ~4 req/s
+const AVAIL_DAYS_LIMIT = 5; // jours de créneaux récupérés par psy
 
 /** Nombre de requêtes SSF initiales utilisées pour détecter un blocage Cloudflare. */
 const BLOCK_SAMPLE_SIZE = 10;
-/** Proportion d'échecs (403/429/réseau) déclenchant le flag de blocage. */
+/** Proportion d'échecs (403/429) déclenchant le flag de blocage. */
 const BLOCK_THRESHOLD = 0.8;
 
 const HEADERS: Record<string, string> = {
@@ -47,11 +53,7 @@ const throttledFetch = async (url: string, signal?: AbortSignal): Promise<Respon
   const now = Date.now();
   const wait = Math.max(0, nextAllowedAt - now);
   nextAllowedAt = Math.max(now, nextAllowedAt) + RATE_MS;
-
-  if (wait > 0) {
-    await new Promise<void>(resolve => setTimeout(resolve, wait));
-  }
-
+  if (wait > 0) await new Promise<void>(resolve => setTimeout(resolve, wait));
   return fetch(url, { headers: HEADERS, signal });
 };
 
@@ -70,7 +72,6 @@ type PsyWithLink = {
   doctolibUrl: string;
 };
 
-/** Résultat d'un appel SSF : null si échec, avec un flag `blocked` si c'est un 403/429. */
 type MetaResult =
   | { meta: DoctolibMeta; blocked: false }
   | { meta: null; blocked: boolean };
@@ -91,7 +92,7 @@ const extractDoctolibUrl = (
   return null;
 };
 
-// ── Étape 1 : métadonnées Doctolib (agenda + motif téléconsultation) ─────────
+// ── Étape 1 : métadonnées Doctolib ───────────────────────────────────────────
 
 const fetchDoctolibMetaWithBlockInfo = async (
   doctolibUrl: string,
@@ -102,12 +103,8 @@ const fetchDoctolibMetaWithBlockInfo = async (
     const url = `${SSF_URL}?profile_slug=${encodeURIComponent(slug)}&locale=fr`;
     const resp = await throttledFetch(url, signal);
 
-    if (resp.status === 403 || resp.status === 429) {
-      return { meta: null, blocked: true };
-    }
-    if (!resp.ok) {
-      return { meta: null, blocked: false };
-    }
+    if (resp.status === 403 || resp.status === 429) return { meta: null, blocked: true };
+    if (!resp.ok) return { meta: null, blocked: false };
 
     const data = await resp.json();
     const root = data.data ?? data;
@@ -136,17 +133,54 @@ const fetchDoctolibMetaWithBlockInfo = async (
   }
 };
 
-export const fetchDoctolibMeta = async (
-  doctolibUrl: string,
+// ── Étape 2 : tous les créneaux disponibles ───────────────────────────────────
+
+/**
+ * Retourne tous les créneaux disponibles pour un psy (sur AVAIL_DAYS_LIMIT jours),
+ * triés par date croissante, dédupliqués.
+ */
+const fetchAllSlots = async (
+  meta: DoctolibMeta,
   signal?: AbortSignal,
-): Promise<DoctolibMeta | null> => {
-  const result = await fetchDoctolibMetaWithBlockInfo(doctolibUrl, signal);
-  return result.meta;
+): Promise<string[]> => {
+  try {
+    const today = new Date().toISOString().slice(0, 10);
+    const params = new URLSearchParams({
+      start_date: today,
+      visit_motive_ids: String(meta.visitMotiveId),
+      agenda_ids: meta.agendaIds,
+      practice_ids: String(meta.practiceId),
+      telehealth: 'true',
+      insurance_sector: 'public',
+      limit: String(AVAIL_DAYS_LIMIT),
+    });
+
+    const resp = await throttledFetch(`${AVAIL_URL}?${params.toString()}`, signal);
+    if (!resp.ok) return [];
+
+    const data = await resp.json();
+
+    // Collecte tous les slots depuis data.availabilities[].slots[]
+    const slots = new Set<string>();
+    for (const day of (data.availabilities ?? []) as Array<{ slots?: string[] }>) {
+      for (const slot of (day.slots ?? [])) {
+        slots.add(slot);
+      }
+    }
+    // Inclut next_slot au cas où il ne serait pas dans availabilities
+    if (data.next_slot) slots.add(data.next_slot as string);
+
+    return [...slots].sort();
+  } catch {
+    return [];
+  }
 };
 
-// ── Étape 2 : prochain créneau disponible ─────────────────────────────────────
-
-export const fetchNextSlot = async (
+/**
+ * Version "premier créneau seulement" utilisée lors de la vérification pour
+ * savoir quel est le prochain créneau réel (sans stocker les suivants).
+ */
+const fetchNextSlotOnly = async (
   meta: DoctolibMeta,
   signal?: AbortSignal,
 ): Promise<string | null> => {
@@ -159,17 +193,27 @@ export const fetchNextSlot = async (
       practice_ids: String(meta.practiceId),
       telehealth: 'true',
       insurance_sector: 'public',
-      limit: '3',
+      limit: '1',
     });
-
     const resp = await throttledFetch(`${AVAIL_URL}?${params.toString()}`, signal);
     if (!resp.ok) return null;
-
     const data = await resp.json();
     return (data.next_slot as string) ?? null;
   } catch {
     return null;
   }
+};
+
+// ── Re-fetch d'un seul psy (compteur tombé à 0) ───────────────────────────────
+
+const refetchOnePsy = async (psy: PsyWithLink): Promise<void> => {
+  const name = `${psy.lastName} ${psy.firstNames}`.trim();
+  const result = await fetchDoctolibMetaWithBlockInfo(psy.doctolibUrl);
+  if (!result.meta) return;
+  const slots = await fetchAllSlots(result.meta);
+  await teleconsultationSlots.replaceSlots(
+    psy.dossierNumber, name, psy.doctolibUrl, slots, false,
+  );
 };
 
 // ── Refresh complet (toutes les psys avec lien Doctolib) ─────────────────────
@@ -196,9 +240,8 @@ export const runFullRefresh = async (): Promise<void> => {
       })
       .filter((p): p is PsyWithLink => p !== null);
 
-    await teleconsultationCache.deleteAll();
+    await teleconsultationSlots.deleteAll();
 
-    // ── Détection de blocage sur les N premiers appels ──────────────────────
     let sampleBlocked = 0;
     let sampleTotal = 0;
 
@@ -206,83 +249,125 @@ export const runFullRefresh = async (): Promise<void> => {
       const name = `${psy.lastName} ${psy.firstNames}`.trim();
       const result = await fetchDoctolibMetaWithBlockInfo(psy.doctolibUrl);
 
-      // Mise à jour de l'échantillon de détection
+      // Détection de blocage sur les N premiers appels
       if (sampleTotal < BLOCK_SAMPLE_SIZE) {
         sampleTotal += 1;
         if (result.blocked) sampleBlocked += 1;
-
         if (sampleTotal === BLOCK_SAMPLE_SIZE) {
-          // Décision finale sur le blocage
           doctolibBlocked = sampleBlocked / BLOCK_SAMPLE_SIZE >= BLOCK_THRESHOLD;
-          if (doctolibBlocked) {
-            // Inutile de continuer le scan si Doctolib bloque
-            return;
-          }
+          if (doctolibBlocked) return;
         }
       }
 
-      if (!result.meta) {
-        await teleconsultationCache.upsertSlot(
-          psy.dossierNumber, name, psy.doctolibUrl, null, true,
-        );
-        continue;
-      }
+      if (!result.meta) continue;
 
-      const slot = await fetchNextSlot(result.meta);
-      await teleconsultationCache.upsertSlot(
-        psy.dossierNumber, name, psy.doctolibUrl, slot, true,
+      const slots = await fetchAllSlots(result.meta);
+      await teleconsultationSlots.replaceSlots(
+        psy.dossierNumber, name, psy.doctolibUrl, slots, true,
       );
     }
 
-    // Refresh terminé sans blocage détecté
     doctolibBlocked = false;
   } finally {
     refreshRunning = false;
   }
 };
 
-// ── Vérification des créneaux du top 5 en cache ───────────────────────────────
+// ── Vérification de la liste plate (cache frais, < 15 min) ───────────────────
 
-export const verifySlots = async (entries: CacheEntry[]): Promise<CacheEntry[]> => {
-  const verified: CacheEntry[] = [];
+/**
+ * Parcourt la liste plate triée par date. Pour chaque psy rencontré la première fois,
+ * appelle Doctolib une seule fois. Les créneaux pris sont supprimés du cache.
+ * Si le compteur d'un psy tombe à 0, il est immédiatement re-fetché.
+ * Retourne true si un blocage Cloudflare a été détecté.
+ */
+export const verifySlots = async (): Promise<boolean> => {
+  // On charge plus de lignes que nécessaire pour avoir un buffer si des slots sont pris
+  const candidates = await teleconsultationSlots.getTopN(30);
+
+  // verifiedPsys[psyId] = nextSlot retourné par Doctolib lors de cette passe
+  const verifiedPsys = new Map<string, string | null>();
   let blockedCount = 0;
 
-  for (const entry of entries) {
-    if (!entry.nextSlot) {
-      verified.push({ ...entry, nextSlot: null });
-      continue;
+  // Index de toutes les psys pour pouvoir re-fetcher (dossierNumber → PsyWithLink)
+  // On construit un Map paresseux depuis les entrées du cache
+  const psyIndex = new Map<string, { dossierNumber: string; firstNames: string; lastName: string; doctolibUrl: string }>();
+  for (const entry of candidates) {
+    if (!psyIndex.has(entry.psychologistId)) {
+      psyIndex.set(entry.psychologistId, {
+        dossierNumber: entry.psychologistId,
+        firstNames: '',
+        lastName: entry.psychologistName,
+        doctolibUrl: entry.doctolibUrl,
+      });
     }
-
-    const result = await fetchDoctolibMetaWithBlockInfo(entry.doctolibUrl);
-
-    if (result.blocked) {
-      blockedCount += 1;
-      // On conserve le créneau en cache sans le modifier
-      verified.push(entry);
-      continue;
-    }
-
-    if (!result.meta) {
-      // Profil introuvable (psy supprimé etc.) → on conserve le cache
-      verified.push(entry);
-      continue;
-    }
-
-    const slot = await fetchNextSlot(result.meta);
-    await teleconsultationCache.upsertSlot(
-      entry.psychologistId,
-      entry.psychologistName,
-      entry.doctolibUrl,
-      slot,
-      false,
-    );
-    verified.push({ ...entry, nextSlot: slot ? new Date(slot) : null });
   }
 
-  // Si tous les appels de vérification sont bloqués → flag
-  if (entries.length > 0 && blockedCount === entries.length) {
+  for (const entry of candidates) {
+    const psyId = entry.psychologistId;
+
+    if (verifiedPsys.has(psyId)) {
+      // Ce psy a déjà été vérifié cette passe — on se base sur nextSlot connu
+      const knownNext = verifiedPsys.get(psyId)!;
+      if (knownNext === null) {
+        await teleconsultationSlots.deleteSlot(entry.id);
+        continue;
+      }
+      if (entry.slotDatetime < new Date(knownNext)) {
+        // Ce créneau est antérieur au prochain connu de Doctolib → il a été pris
+        await teleconsultationSlots.deleteSlot(entry.id);
+        const count = await teleconsultationSlots.getSlotCount(psyId);
+        if (count === 0) {
+          const psyInfo = psyIndex.get(psyId);
+          if (psyInfo) await refetchOnePsy(psyInfo);
+        }
+      }
+      // Si slotDatetime >= knownNext → créneau encore valide, rien à faire
+    } else {
+      // Premier contact avec ce psy cette passe : appel Doctolib
+      const metaResult = await fetchDoctolibMetaWithBlockInfo(entry.doctolibUrl);
+
+      if (metaResult.blocked) {
+        blockedCount += 1;
+        verifiedPsys.set(psyId, entry.slotDatetime.toISOString()); // conservatif
+        continue;
+      }
+
+      if (!metaResult.meta) {
+        verifiedPsys.set(psyId, null);
+        await teleconsultationSlots.deleteAllForPsy(psyId);
+        continue;
+      }
+
+      const nextSlot = await fetchNextSlotOnly(metaResult.meta);
+      verifiedPsys.set(psyId, nextSlot);
+
+      if (nextSlot === null) {
+        await teleconsultationSlots.deleteAllForPsy(psyId);
+        continue;
+      }
+
+      if (entry.slotDatetime < new Date(nextSlot)) {
+        // Créneau pris
+        await teleconsultationSlots.deleteSlot(entry.id);
+        const count = await teleconsultationSlots.getSlotCount(psyId);
+        if (count === 0) {
+          const psyInfo = psyIndex.get(psyId);
+          if (psyInfo) await refetchOnePsy(psyInfo);
+        }
+      }
+      // Si slotDatetime >= nextSlot → créneau encore valide
+    }
+  }
+
+  // Si tous les appels ont été bloqués → flag global
+  const uniquePsysChecked = [...verifiedPsys.keys()].filter(
+    id => !verifiedPsys.get(id) || verifiedPsys.get(id) !== null,
+  ).length;
+  if (uniquePsysChecked > 0 && blockedCount === uniquePsysChecked) {
     doctolibBlocked = true;
+    return true;
   }
 
-  return verified.filter(e => e.nextSlot && e.nextSlot >= new Date());
+  return false;
 };

--- a/services/doctolibAvailability.ts
+++ b/services/doctolibAvailability.ts
@@ -1,0 +1,215 @@
+/**
+ * Service d'interrogation de l'API publique Doctolib pour récupérer les créneaux de
+ * téléconsultation disponibles.
+ *
+ * Doctolib est protégé par Cloudflare. On tente les appels avec des en-têtes qui
+ * ressemblent à ceux d'un vrai navigateur Chrome. Si le serveur de production
+ * Scalingo est bloqué (403), les fonctions retournent null et le backend dégrade
+ * gracieusement (affiche le lien Doctolib sans créneau).
+ */
+
+import dbPsychologists from '../db/psychologists';
+import teleconsultationCache, { CacheEntry } from '../db/teleconsultationCache';
+import { Psychologist } from '../types/Psychologist';
+
+const DOCTOLIB_BASE = 'https://www.doctolib.fr';
+const SSF_URL = `${DOCTOLIB_BASE}/online_booking/api/slot_selection_funnel/v1/info.json`;
+const AVAIL_URL = `${DOCTOLIB_BASE}/availabilities.json`;
+const RATE_MS = 250; // ~4 req/s
+
+const HEADERS: Record<string, string> = {
+  'User-Agent':
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
+  Accept: 'application/json, text/plain, */*',
+  'Accept-Language': 'fr-FR,fr;q=0.9',
+  Referer: `${DOCTOLIB_BASE}/`,
+};
+
+// ── Rate limiter (token bucket) ─────────────────────────────────────────────
+
+let nextAllowedAt = 0;
+
+const throttledFetch = async (url: string, signal?: AbortSignal): Promise<Response> => {
+  const now = Date.now();
+  const wait = Math.max(0, nextAllowedAt - now);
+  nextAllowedAt = Math.max(now, nextAllowedAt) + RATE_MS;
+
+  if (wait > 0) {
+    await new Promise<void>(resolve => setTimeout(resolve, wait));
+  }
+
+  return fetch(url, { headers: HEADERS, signal });
+};
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+type DoctolibMeta = {
+  agendaIds: string;
+  practiceId: number;
+  visitMotiveId: number;
+};
+
+type PsyWithLink = {
+  dossierNumber: string;
+  firstNames: string;
+  lastName: string;
+  doctolibUrl: string;
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const extractSlug = (url: string): string => url.replace(/\/$/, '').split('/').pop() ?? '';
+
+const extractDoctolibUrl = (
+  psy: Pick<Psychologist, 'appointmentLink' | 'website'>,
+): string | null => {
+  for (const field of ['appointmentLink', 'website'] as const) {
+    const val = (psy[field] ?? '').toLowerCase();
+    if (val.includes('doctolib.fr')) {
+      return (psy[field] as string).split('?')[0].replace(/\/$/, '');
+    }
+  }
+  return null;
+};
+
+// ── Étape 1 : métadonnées Doctolib (agenda + motif téléconsultation) ─────────
+
+export const fetchDoctolibMeta = async (
+  doctolibUrl: string,
+  signal?: AbortSignal,
+): Promise<DoctolibMeta | null> => {
+  try {
+    const slug = extractSlug(doctolibUrl);
+    const url = `${SSF_URL}?profile_slug=${encodeURIComponent(slug)}&locale=fr`;
+    const resp = await throttledFetch(url, signal);
+
+    if (!resp.ok) return null;
+
+    const data = await resp.json();
+    const root = data.data ?? data;
+    const agendas: Array<{ id: number; practice_id: number }> = root.agendas ?? [];
+    const visitMotives: Array<{ id: number; name: string; telehealth: boolean }> =
+      root.visit_motives ?? [];
+
+    if (!agendas.length || !visitMotives.length) return null;
+
+    const telehealth = visitMotives.filter(m => m.telehealth);
+    if (!telehealth.length) return null;
+
+    const motive =
+      telehealth.find(m => m.name.toLowerCase().includes('nouveau')) ?? telehealth[0];
+
+    return {
+      agendaIds: agendas.map(a => a.id).join('-'),
+      practiceId: agendas[0].practice_id,
+      visitMotiveId: motive.id,
+    };
+  } catch {
+    return null;
+  }
+};
+
+// ── Étape 2 : prochain créneau disponible ─────────────────────────────────────
+
+export const fetchNextSlot = async (
+  meta: DoctolibMeta,
+  signal?: AbortSignal,
+): Promise<string | null> => {
+  try {
+    const today = new Date().toISOString().slice(0, 10);
+    const params = new URLSearchParams({
+      start_date: today,
+      visit_motive_ids: String(meta.visitMotiveId),
+      agenda_ids: meta.agendaIds,
+      practice_ids: String(meta.practiceId),
+      telehealth: 'true',
+      insurance_sector: 'public',
+      limit: '3',
+    });
+
+    const resp = await throttledFetch(`${AVAIL_URL}?${params.toString()}`, signal);
+    if (!resp.ok) return null;
+
+    const data = await resp.json();
+    return (data.next_slot as string) ?? null;
+  } catch {
+    return null;
+  }
+};
+
+// ── Refresh complet (toutes les psys avec lien Doctolib) ─────────────────────
+
+let refreshRunning = false;
+
+export const runFullRefresh = async (): Promise<void> => {
+  if (refreshRunning) return;
+  refreshRunning = true;
+
+  try {
+    const allPsys = await dbPsychologists.getAllAcceptedWithTeleconsultation();
+
+    const psysWithLink: PsyWithLink[] = allPsys
+      .map(psy => {
+        const url = extractDoctolibUrl(psy);
+        if (!url) return null;
+        return {
+          dossierNumber: psy.dossierNumber,
+          firstNames: psy.firstNames ?? '',
+          lastName: psy.lastName ?? '',
+          doctolibUrl: url,
+        };
+      })
+      .filter((p): p is PsyWithLink => p !== null);
+
+    await teleconsultationCache.deleteAll();
+
+    for (const psy of psysWithLink) {
+      const name = `${psy.lastName} ${psy.firstNames}`.trim();
+      const meta = await fetchDoctolibMeta(psy.doctolibUrl);
+      if (!meta) {
+        await teleconsultationCache.upsertSlot(
+          psy.dossierNumber, name, psy.doctolibUrl, null, true,
+        );
+        continue;
+      }
+      const slot = await fetchNextSlot(meta);
+      await teleconsultationCache.upsertSlot(
+        psy.dossierNumber, name, psy.doctolibUrl, slot, true,
+      );
+    }
+  } finally {
+    refreshRunning = false;
+  }
+};
+
+// ── Vérification des créneaux du top 5 en cache ───────────────────────────────
+
+export const verifySlots = async (entries: CacheEntry[]): Promise<CacheEntry[]> => {
+  const verified: CacheEntry[] = [];
+
+  for (const entry of entries) {
+    if (!entry.nextSlot) {
+      verified.push({ ...entry, nextSlot: null });
+      continue;
+    }
+
+    const meta = await fetchDoctolibMeta(entry.doctolibUrl);
+    if (!meta) {
+      // Impossible de vérifier : on conserve le créneau mis en cache
+      verified.push(entry);
+      continue;
+    }
+
+    const slot = await fetchNextSlot(meta);
+    await teleconsultationCache.upsertSlot(
+      entry.psychologistId,
+      entry.psychologistName,
+      entry.doctolibUrl,
+      slot,
+      false,
+    );
+    verified.push({ ...entry, nextSlot: slot ? new Date(slot) : null });
+  }
+
+  return verified.filter(e => e.nextSlot && e.nextSlot >= new Date());
+};

--- a/services/doctolibAvailability.ts
+++ b/services/doctolibAvailability.ts
@@ -3,9 +3,11 @@
  * téléconsultation disponibles.
  *
  * Doctolib est protégé par Cloudflare. On tente les appels avec des en-têtes qui
- * ressemblent à ceux d'un vrai navigateur Chrome. Si le serveur de production
- * Scalingo est bloqué (403), les fonctions retournent null et le backend dégrade
- * gracieusement (affiche le lien Doctolib sans créneau).
+ * ressemblent à ceux d'un vrai navigateur Chrome.
+ *
+ * Détection de blocage : si >= 80 % des 10 premières requêtes SSF d'un refresh
+ * retournent 403, on positionne doctolibBlocked = true. Le flag se réinitialise
+ * au prochain refresh complet si les requêtes repassent.
  */
 
 import dbPsychologists from '../db/psychologists';
@@ -17,6 +19,11 @@ const SSF_URL = `${DOCTOLIB_BASE}/online_booking/api/slot_selection_funnel/v1/in
 const AVAIL_URL = `${DOCTOLIB_BASE}/availabilities.json`;
 const RATE_MS = 250; // ~4 req/s
 
+/** Nombre de requêtes SSF initiales utilisées pour détecter un blocage Cloudflare. */
+const BLOCK_SAMPLE_SIZE = 10;
+/** Proportion d'échecs (403/429/réseau) déclenchant le flag de blocage. */
+const BLOCK_THRESHOLD = 0.8;
+
 const HEADERS: Record<string, string> = {
   'User-Agent':
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36',
@@ -24,6 +31,13 @@ const HEADERS: Record<string, string> = {
   'Accept-Language': 'fr-FR,fr;q=0.9',
   Referer: `${DOCTOLIB_BASE}/`,
 };
+
+// ── Détection de blocage Cloudflare ──────────────────────────────────────────
+
+let doctolibBlocked = false;
+
+/** Retourne true si Doctolib bloque les requêtes serveur (Cloudflare WAF). */
+export const isDoctolibBlocked = (): boolean => doctolibBlocked;
 
 // ── Rate limiter (token bucket) ─────────────────────────────────────────────
 
@@ -56,6 +70,11 @@ type PsyWithLink = {
   doctolibUrl: string;
 };
 
+/** Résultat d'un appel SSF : null si échec, avec un flag `blocked` si c'est un 403/429. */
+type MetaResult =
+  | { meta: DoctolibMeta; blocked: false }
+  | { meta: null; blocked: boolean };
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 const extractSlug = (url: string): string => url.replace(/\/$/, '').split('/').pop() ?? '';
@@ -74,16 +93,21 @@ const extractDoctolibUrl = (
 
 // ── Étape 1 : métadonnées Doctolib (agenda + motif téléconsultation) ─────────
 
-export const fetchDoctolibMeta = async (
+const fetchDoctolibMetaWithBlockInfo = async (
   doctolibUrl: string,
   signal?: AbortSignal,
-): Promise<DoctolibMeta | null> => {
+): Promise<MetaResult> => {
   try {
     const slug = extractSlug(doctolibUrl);
     const url = `${SSF_URL}?profile_slug=${encodeURIComponent(slug)}&locale=fr`;
     const resp = await throttledFetch(url, signal);
 
-    if (!resp.ok) return null;
+    if (resp.status === 403 || resp.status === 429) {
+      return { meta: null, blocked: true };
+    }
+    if (!resp.ok) {
+      return { meta: null, blocked: false };
+    }
 
     const data = await resp.json();
     const root = data.data ?? data;
@@ -91,22 +115,33 @@ export const fetchDoctolibMeta = async (
     const visitMotives: Array<{ id: number; name: string; telehealth: boolean }> =
       root.visit_motives ?? [];
 
-    if (!agendas.length || !visitMotives.length) return null;
+    if (!agendas.length || !visitMotives.length) return { meta: null, blocked: false };
 
     const telehealth = visitMotives.filter(m => m.telehealth);
-    if (!telehealth.length) return null;
+    if (!telehealth.length) return { meta: null, blocked: false };
 
     const motive =
       telehealth.find(m => m.name.toLowerCase().includes('nouveau')) ?? telehealth[0];
 
     return {
-      agendaIds: agendas.map(a => a.id).join('-'),
-      practiceId: agendas[0].practice_id,
-      visitMotiveId: motive.id,
+      meta: {
+        agendaIds: agendas.map(a => a.id).join('-'),
+        practiceId: agendas[0].practice_id,
+        visitMotiveId: motive.id,
+      },
+      blocked: false,
     };
   } catch {
-    return null;
+    return { meta: null, blocked: false };
   }
+};
+
+export const fetchDoctolibMeta = async (
+  doctolibUrl: string,
+  signal?: AbortSignal,
+): Promise<DoctolibMeta | null> => {
+  const result = await fetchDoctolibMetaWithBlockInfo(doctolibUrl, signal);
+  return result.meta;
 };
 
 // ── Étape 2 : prochain créneau disponible ─────────────────────────────────────
@@ -163,20 +198,44 @@ export const runFullRefresh = async (): Promise<void> => {
 
     await teleconsultationCache.deleteAll();
 
+    // ── Détection de blocage sur les N premiers appels ──────────────────────
+    let sampleBlocked = 0;
+    let sampleTotal = 0;
+
     for (const psy of psysWithLink) {
       const name = `${psy.lastName} ${psy.firstNames}`.trim();
-      const meta = await fetchDoctolibMeta(psy.doctolibUrl);
-      if (!meta) {
+      const result = await fetchDoctolibMetaWithBlockInfo(psy.doctolibUrl);
+
+      // Mise à jour de l'échantillon de détection
+      if (sampleTotal < BLOCK_SAMPLE_SIZE) {
+        sampleTotal += 1;
+        if (result.blocked) sampleBlocked += 1;
+
+        if (sampleTotal === BLOCK_SAMPLE_SIZE) {
+          // Décision finale sur le blocage
+          doctolibBlocked = sampleBlocked / BLOCK_SAMPLE_SIZE >= BLOCK_THRESHOLD;
+          if (doctolibBlocked) {
+            // Inutile de continuer le scan si Doctolib bloque
+            return;
+          }
+        }
+      }
+
+      if (!result.meta) {
         await teleconsultationCache.upsertSlot(
           psy.dossierNumber, name, psy.doctolibUrl, null, true,
         );
         continue;
       }
-      const slot = await fetchNextSlot(meta);
+
+      const slot = await fetchNextSlot(result.meta);
       await teleconsultationCache.upsertSlot(
         psy.dossierNumber, name, psy.doctolibUrl, slot, true,
       );
     }
+
+    // Refresh terminé sans blocage détecté
+    doctolibBlocked = false;
   } finally {
     refreshRunning = false;
   }
@@ -186,6 +245,7 @@ export const runFullRefresh = async (): Promise<void> => {
 
 export const verifySlots = async (entries: CacheEntry[]): Promise<CacheEntry[]> => {
   const verified: CacheEntry[] = [];
+  let blockedCount = 0;
 
   for (const entry of entries) {
     if (!entry.nextSlot) {
@@ -193,14 +253,22 @@ export const verifySlots = async (entries: CacheEntry[]): Promise<CacheEntry[]> 
       continue;
     }
 
-    const meta = await fetchDoctolibMeta(entry.doctolibUrl);
-    if (!meta) {
-      // Impossible de vérifier : on conserve le créneau mis en cache
+    const result = await fetchDoctolibMetaWithBlockInfo(entry.doctolibUrl);
+
+    if (result.blocked) {
+      blockedCount += 1;
+      // On conserve le créneau en cache sans le modifier
       verified.push(entry);
       continue;
     }
 
-    const slot = await fetchNextSlot(meta);
+    if (!result.meta) {
+      // Profil introuvable (psy supprimé etc.) → on conserve le cache
+      verified.push(entry);
+      continue;
+    }
+
+    const slot = await fetchNextSlot(result.meta);
     await teleconsultationCache.upsertSlot(
       entry.psychologistId,
       entry.psychologistName,
@@ -209,6 +277,11 @@ export const verifySlots = async (entries: CacheEntry[]): Promise<CacheEntry[]> 
       false,
     );
     verified.push({ ...entry, nextSlot: slot ? new Date(slot) : null });
+  }
+
+  // Si tous les appels de vérification sont bloqués → flag
+  if (entries.length > 0 && blockedCount === entries.length) {
+    doctolibBlocked = true;
   }
 
   return verified.filter(e => e.nextSlot && e.nextSlot >= new Date());

--- a/services/doctolibAvailability.ts
+++ b/services/doctolibAvailability.ts
@@ -282,8 +282,8 @@ export const runFullRefresh = async (): Promise<void> => {
  * Retourne true si un blocage Cloudflare a été détecté.
  */
 export const verifySlots = async (): Promise<boolean> => {
-  // On charge plus de lignes que nécessaire pour avoir un buffer si des slots sont pris
-  const candidates = await teleconsultationSlots.getTopN(30);
+  // Liste plate (multi-créneaux par psy) pour naviguer les slots pris sans appel Doctolib
+  const candidates = await teleconsultationSlots.getFlatTopN(30);
 
   // verifiedPsys[psyId] = nextSlot retourné par Doctolib lors de cette passe
   const verifiedPsys = new Map<string, string | null>();


### PR DESCRIPTION
## Résumé

Ce PR ajoute un bouton **« Voir les premières disponibilités en téléconsultation »** sur la page de recherche de psychologues. En cliquant, l'étudiant obtient les 5 psychologues avec la prochaine disponibilité en téléconsultation la plus proche, avec un lien direct Doctolib.

## Fonctionnement

### Cache multi-créneaux (`teleconsultation_slots`)
- Une ligne par créneau — les créneaux de chaque psy sont stockés sur ~5 jours
- Liste plate triée par `slotDatetime ASC` avec `DISTINCT ON` pour n'afficher qu'un créneau par praticien
- TTL de 15 minutes : si le cache est périmé, la réponse est renvoyée immédiatement et un refresh complet est lancé en arrière-plan

### Vérification intelligente (clic bouton, cache < 15 min)
- **1 seul appel Doctolib par praticien** par passe de vérification
- Si le créneau #1 d'un psy est pris → son créneau #2 remonte **sans appel Doctolib supplémentaire**
- Si le compteur de créneaux d'un psy tombe à 0 → re-fetch immédiat inline

### Détection de blocage Cloudflare
- Si ≥ 80 % des 10 premiers appels SSF retournent 403 → flag `doctolibBlocked = true`
- Le bouton disparaît entièrement du frontend quand le serveur est bloqué
- Le flag se réinitialise au prochain refresh complet réussi

### Pas de cron automatique
Le scraping Doctolib ne se déclenche **que quand un utilisateur clique** — aucune charge en dehors des sessions actives.

## Fichiers modifiés

| Fichier | Rôle |
|---|---|
| `migrations/20260328130000_replace_teleconsultation_cache.ts` | Table `teleconsultation_slots` |
| `db/teleconsultationCache.ts` | Couche DB : getTopN, getFlatTopN, replaceSlots, deleteSlot… |
| `db/psychologists.ts` | Ajout `getAllAcceptedWithTeleconsultation()` |
| `services/doctolibAvailability.ts` | Appels Doctolib, rate-limit, détection blocage, verifySlots |
| `controllers/teleconsultationRapideController.ts` | Endpoint GET `/api/teleconsultation-rapide` |
| `routers/unprotected.ts` | Route publique |
| `frontend/src/components/PsyListing/TeleconsultationRapide.jsx` | Composant React (DSFR) |
| `frontend/src/components/PsyListing/PsyListing.jsx` | Intégration du composant |
| `frontend/src/services/agent.js` | Appel API `fastestTeleconsultation()` |

## Test plan

- [ ] `pnpm migrate` → table `teleconsultation_slots` créée
- [ ] Premier clic → refresh complet (~3 min), top 5 affiché
- [ ] Re-clic < 15 min → réponse immédiate, créneaux vérifiés
- [ ] Re-clic > 15 min → réponse immédiate (stale) + refresh en arrière-plan
- [ ] Vérifier qu'un même praticien n'apparaît pas deux fois
- [ ] Si Doctolib bloque → bouton masqué

🤖 Generated with [Claude Code](https://claude.com/claude-code)